### PR TITLE
WIP: prepare script is needed for installing dependencies from git using npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   ],
   "scripts": {
     "prepack": "yarn run build",
+    "prepare": "yarn run build",
     "lint": "eslint . --ext .ts",
     "lint:fix": "yarn lint --fix",
     "test": "yarn run jest --verbose --testPathIgnorePatterns 'web'",


### PR DESCRIPTION
Hello! 

The `prepare` script is needed in a library in order to make the library installable with `npm` from a git URL in a consuming project's `package.json`.

F.e. A consuming project would have the following to install `rosbag` from git:

```json
"dependencies": {
  "rosbag": "foxglove/rosbag.js",
}
```

However, there's an issue with having both `prepack` and `prepare` scripts when using `npm`: `npm` will run both of them, but when `npm` runs `prepack`, `devDependencies` of the library being installed (f.e. `devDependencies` of `rosbag` while it is being installed from git) will not be available yet, so the build will fail.

The solution to make this work in `npm` is to delete the `prepack` script, and just use `prepare`.

But here's the bad part!

Last I checked, Yarn intentionally [does not run `prepare` scripts](https://github.com/yarnpkg/berry/issues/2305). Instead, Yarn only runs `prepack` scripts, and `devDependencies` are available during `prepack` for `yarn` users, so installing from git with `yarn` works.

Basically Yarn deviated quite significantly from `npm` here, which makes the two totally incompatible with each other when install from git.

If `yarn` must be supported, then adding a `prepare` script and not deleting the `prepack` script won't work. In this case we would need to be sure to change the name of the package and publish it so `npm` users can install from the npm registry.

If `npm` users would like to install the latest from `git` though (while not breaking this for `yarn` users), they would need to clone the project, publish it under their own name, and use a [`package.json` alias](https://stackoverflow.com/a/61246743/454780):

```json
"dependencies": {
    "rosbag": "npm:@my-scope/rosbag@^1.6.1"
}
```