### PR TITLE
Promisify

### DIFF
--- a/src/Bag.test.ts
+++ b/src/Bag.test.ts
@@ -38,7 +38,7 @@ async function fullyReadBag<T>(name: string, opts?: ReadOptions): Promise<ReadRe
 describe("basics", () => {
   it("handles empty and non-existent bags", async () => {
     await expect(Bag.open(getFixture("NON_EXISTENT_FILE"))).rejects.toThrow("no such file or directory");
-    await expect(Bag.open(getFixture("empty-file"))).rejects.toThrow("Missing file header.");
+    await expect(Bag.open(getFixture("empty-file"))).rejects.toThrow("Attempted to read 13 bytes");
     await expect(fullyReadBag("no-messages")).resolves.toEqual([]);
   });
 });

--- a/src/Bag.ts
+++ b/src/Bag.ts
@@ -53,10 +53,10 @@ export default class Bag {
   // if the bag is manually created with the constructor, you must call `await open()` on the bag
   // generally this is called for you if you're using `const bag = await Bag.open()`
   async open(): Promise<void> {
-    this.header = await this.reader.readHeaderAsync();
+    this.header = await this.reader.readHeader();
     const { connectionCount, chunkCount, indexPosition } = this.header;
 
-    const result = await this.reader.readConnectionsAndChunkInfoAsync(indexPosition, connectionCount, chunkCount);
+    const result = await this.reader.readConnectionsAndChunkInfo(indexPosition, connectionCount, chunkCount);
 
     this.connections = new Map<number, Connection>();
 
@@ -115,13 +115,7 @@ export default class Bag {
 
     for (let i = 0; i < chunkInfos.length; i++) {
       const info = chunkInfos[i]!;
-      const messages = await this.reader.readChunkMessagesAsync(
-        info,
-        filteredConnections,
-        startTime,
-        endTime,
-        decompress
-      );
+      const messages = await this.reader.readChunkMessages(info, filteredConnections, startTime, endTime, decompress);
       messages.forEach((msg) => callback(parseMsg(msg, i)));
     }
   }

--- a/src/node/index.test.ts
+++ b/src/node/index.test.ts
@@ -14,16 +14,11 @@ describe("node entrypoint", () => {
   describe("Reader", () => {
     const fixture = path.join(__dirname, "..", "..", "fixtures", "asci-file.txt");
 
-    // eslint-disable-next-line jest/no-done-callback
-    it("should read bytes from a file", (done) => {
+    it("should read bytes from a file", async () => {
       const reader = new Reader(fixture);
-      reader.read(5, 10, (err?: Error | null, buff?: Buffer | null) => {
-        expect(err).toBeNull();
-        expect(buff).not.toBeNull();
-        expect(reader.size()).toBe(fs.statSync(fixture).size);
-        expect(buff!.toString()).toBe("6789012345");
-        reader.close(done);
-      });
+      const buff = await reader.read(5, 10);
+      expect(reader.size()).toBe(fs.statSync(fixture).size);
+      expect(buff.toString()).toBe("6789012345");
     });
   });
 });

--- a/src/node/index.ts
+++ b/src/node/index.ts
@@ -8,65 +8,51 @@
 /* eslint-disable filenames/match-exported */
 
 import { Buffer } from "buffer";
-import * as fs from "fs";
+import * as fs from "fs/promises";
 
 import Bag from "../Bag";
 import BagReader from "../BagReader";
-import { Callback } from "../types";
+import { Filelike } from "../types";
 
 // reader using nodejs fs api
-export class Reader {
+export class Reader implements Filelike {
   _filename: string;
-  _fd: number | null | undefined;
+  _file?: fs.FileHandle;
   _size: number;
   _buffer: Buffer;
 
   constructor(filename: string) {
     this._filename = filename;
-    this._fd = undefined;
+    this._file = undefined;
     this._size = 0;
     this._buffer = Buffer.allocUnsafe(0);
   }
 
   // open a file for reading
-  _open(cb: (error: Error | null | undefined) => void): void {
-    fs.stat(this._filename, (error, stat) => {
-      if (error != null) {
-        return cb(error);
-      }
-
-      return fs.open(this._filename, "r", (err, fd) => {
-        if (err != null) {
-          return cb(err);
-        }
-
-        this._fd = fd;
-        this._size = stat.size;
-        return cb(null);
-      });
-    });
+  private async _open(): Promise<void> {
+    this._file = await fs.open(this._filename, "r");
+    this._size = (await this._file.stat()).size;
   }
 
-  close(cb: (error: Error | null | undefined) => void): void {
-    if (this._fd != null) {
-      fs.close(this._fd, cb);
-    }
+  async close(): Promise<void> {
+    await this._file?.close();
   }
 
   // read length (bytes) starting from offset (bytes)
   // callback(err, buffer)
-  read(offset: number, length: number, cb: Callback<Buffer>): void {
-    if (this._fd == null) {
-      return this._open((err) => {
-        return err != null ? cb(err) : this.read(offset, length, cb);
-      });
+  async read(offset: number, length: number): Promise<Buffer> {
+    if (this._file == null) {
+      await this._open();
+      return await this.read(offset, length);
     }
     if (length > this._buffer.byteLength) {
       this._buffer = Buffer.alloc(length);
     }
-    return fs.read(this._fd, this._buffer, 0, length, offset, (err, _bytes, buff) => {
-      return err != null ? cb(err) : cb(null, buff);
-    });
+    const { bytesRead } = await this._file.read(this._buffer, 0, length, offset);
+    if (bytesRead < length) {
+      throw new Error(`Attempted to read ${length} bytes at offset ${offset} but only ${bytesRead} were available`);
+    }
+    return this._buffer;
   }
 
   // return the size of the file

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,6 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-// A function that must be called with either an error or a value, but not both
-export interface Callback<T> {
-  (err: Error, result?: null): void;
-  (err: undefined | null, result: T): void;
-}
-
 export type RawFields = { [k: string]: Buffer };
 
 export interface Constructor<T> {
@@ -18,6 +12,6 @@ export interface Constructor<T> {
 }
 
 export interface Filelike {
-  read(offset: number, length: number, callback: Callback<Buffer>): void;
+  read(offset: number, length: number): Promise<Buffer>;
   size(): number;
 }


### PR DESCRIPTION
Several methods had both callback and async versions. Remove all callback-style methods in favor of returning Promises.