### PR TITLE
Remove dynamic-patching the open static method on Bag class

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ The most common way to interact with a rosbag is to read data records for a spec
 Here is an example of reading messages from a rosbag in node.js:
 
 ```typescript
-const { open } = require("rosbag");
+import { Bag, BagReader } from "@foxglove/rosbag";
+import { FileReader } from "@foxglove/rosbag/node";
 
 async function logMessagesFromFooBar() {
   // open a new bag at a given file location:
-  const bag = await open("../path/to/ros.bag");
+  const bag = new Bag(new BagReader(new FileReader("../path/to/ros.bag")));
+
+  await bag.open();
 
   // read all messages from both the '/foo' and '/bar' topics:
   await bag.readMessages({ topics: ["/foo", "/bar"] }, (result) => {
@@ -43,14 +46,6 @@ logMessagesFromFooBar();
 ```
 
 ## API
-
-### Opening a new rosbag reader
-
-```typescript
-function open(fileOrPath: File | string) => Promise<Bag>
-```
-
-Opening a new rosbag reader is done with the `open` function. In the browser the function takes [a File instance](https://developer.mozilla.org/en-US/docs/Web/API/File) which you will generally get from a file input element. In node.js the function takes a string which should be the full path to a rosbag file. Node.js will read the file off of the disk. The promise will reject if there is an issue opening the file or if the file format is invalid, otherwise it will resolve with an instance of a `Bag`.
 
 ### Bag instance
 

--- a/src/Bag.ts
+++ b/src/Bag.ts
@@ -38,17 +38,10 @@ export default class Bag {
   startTime: Time | null | undefined;
   endTime: Time | null | undefined;
 
-  // you can optionally create a bag manually passing in a bagReader instance
   constructor(bagReader: BagReader) {
     this.reader = bagReader;
     this.connections = new Map<number, Connection>();
   }
-
-  static open = async (_file: File | string): Promise<Bag> => {
-    throw new Error(
-      "This method should have been overridden based on the environment. Make sure you are correctly importing the node or web version of Bag."
-    );
-  };
 
   // if the bag is manually created with the constructor, you must call `await open()` on the bag
   // generally this is called for you if you're using `const bag = await Bag.open()`

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,5 @@
+import Bag from "./Bag";
+import BagReader from "./BagReader";
+
+export type { Filelike } from "./types";
+export { Bag, BagReader };

--- a/src/node/FileReader.test.ts
+++ b/src/node/FileReader.test.ts
@@ -8,14 +8,14 @@
 import fs from "fs";
 import path from "path";
 
-import { Reader } from ".";
+import FileReader from "./FileReader";
 
 describe("node entrypoint", () => {
   describe("Reader", () => {
     const fixture = path.join(__dirname, "..", "..", "fixtures", "asci-file.txt");
 
     it("should read bytes from a file", async () => {
-      const reader = new Reader(fixture);
+      const reader = new FileReader(fixture);
       const buff = await reader.read(5, 10);
       expect(reader.size()).toBe(fs.statSync(fixture).size);
       expect(buff).toEqual(Uint8Array.from([54, 55, 56, 57, 48, 49, 50, 51, 52, 53]));

--- a/src/node/FileReader.ts
+++ b/src/node/FileReader.ts
@@ -5,16 +5,12 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-/* eslint-disable filenames/match-exported */
-
 import * as fs from "fs/promises";
 
-import Bag from "../Bag";
-import BagReader from "../BagReader";
 import { Filelike } from "../types";
 
 // reader using nodejs fs api
-export class Reader implements Filelike {
+export default class FileReader implements Filelike {
   _filename: string;
   _file?: fs.FileHandle;
   _size: number;
@@ -59,19 +55,3 @@ export class Reader implements Filelike {
     return this._size;
   }
 }
-
-const open = async (filename: File | string): Promise<Bag> => {
-  if (typeof filename !== "string") {
-    throw new Error(
-      "Expected filename to be a string. Make sure you are correctly importing the node or web version of Bag."
-    );
-  }
-  const bag = new Bag(new BagReader(new Reader(filename)));
-  await bag.open();
-  return bag;
-};
-Bag.open = open;
-
-export type { Filelike } from "../types";
-export { BagReader, open };
-export default Bag;

--- a/src/web/BlobReader.test.ts
+++ b/src/web/BlobReader.test.ts
@@ -7,10 +7,9 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
-import * as fs from "fs";
 import { TextEncoder, TextDecoder } from "util";
 
-import Bag, { Reader } from ".";
+import BlobReader from "./BlobReader";
 
 // github.com/jsdom/jsdom/issues/2524
 global.TextEncoder = TextEncoder;
@@ -20,7 +19,7 @@ global.TextDecoder = TextDecoder;
 describe("browser reader", () => {
   it("works in node", async () => {
     const buffer = new Blob([Uint8Array.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
-    const reader = new Reader(buffer);
+    const reader = new BlobReader(buffer);
     const res = await reader.read(0, 2);
     expect(res).toHaveLength(2);
     expect(res instanceof Uint8Array).toBe(true);
@@ -29,15 +28,9 @@ describe("browser reader", () => {
     expect(buff[1]).toBe(0x01);
   });
 
-  it("propagates error for truncated bag", async () => {
-    const data = fs.readFileSync(`${__dirname}/../../fixtures/example.bag`);
-    const file = new File([data.slice(0, data.length - 1)], "example.bag");
-    await expect(Bag.open(file)).rejects.toThrow("Offset is outside the bounds of the DataView");
-  });
-
   it("allows multiple read operations at once", async () => {
     const buffer = new Blob([Uint8Array.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
-    const reader = new Reader(buffer);
+    const reader = new BlobReader(buffer);
     await expect(Promise.all([reader.read(0, 2), reader.read(0, 2)])).resolves.toEqual([
       Uint8Array.from([0, 1]),
       Uint8Array.from([0, 1]),
@@ -46,7 +39,7 @@ describe("browser reader", () => {
 
   it("reports browser FileReader errors", async () => {
     const buffer = new Blob([Uint8Array.from([0x00, 0x01, 0x02, 0x03, 0x04])]);
-    const reader = new Reader(buffer);
+    const reader = new BlobReader(buffer);
     const actualFileReader = global.FileReader;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (global as any).FileReader = class FailReader {


### PR DESCRIPTION
Specifying the reader explicitly reduces guessing and allows the caller
to determine how best to load bags in their environment.

Fixes: #17 