### PR TITLE
Fix git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum || true)",
-    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum || true)",
+    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && cat dist/tsconfig.tsbuildinfo",
+    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && cat dist/tsconfig.tsbuildinfo",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json",
-    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json",
+    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && ls -l src dist",
+    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && ls -l src dist",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && cat dist/tsconfig.tsbuildinfo",
-    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && cat dist/tsconfig.tsbuildinfo",
+    "prepack": "tsc -b tsconfig.json tsconfig.cjs.json",
+    "build": "tsc -b tsconfig.json tsconfig.cjs.json",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest",
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.13.0",
-    "@foxglove/tsconfig": "1.0.0",
+    "@foxglove/tsconfig": "1.1.0",
     "@types/heap": "0.2.28",
     "@types/jest": "26.0.20",
     "@types/node": "14.14.25",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum)",
-    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum)",
+    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum || true)",
+    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum || true)",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && ls -l src dist",
-    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && ls -l src dist",
+    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum)",
+    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json && (find src dist | xargs shasum)",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "scripts": {
     "clean": "rimraf dist *.tsbuildinfo",
-    "prepack": "tsc -b tsconfig.json tsconfig.cjs.json",
-    "build": "tsc -b tsconfig.json tsconfig.cjs.json",
+    "prepack": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json",
+    "build": "yarn clean && tsc -b tsconfig.json tsconfig.cjs.json",
     "lint": "eslint --report-unused-disable-directives --fix .",
     "lint:ci": "eslint --report-unused-disable-directives .",
     "test": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -346,10 +346,10 @@
   resolved "https://registry.yarnpkg.com/@foxglove/rostime/-/rostime-1.1.0.tgz#6a75ae46fdd17854a0033954f240bb6bda4b5e45"
   integrity sha512-9f/oxnEgaOcXyAQEamv/GpbTnfg872XRxXY97xfWI5WweR2+ERqDswM6hQLLznIQWeTiKVAsc4DNwEQKBeUhhg==
 
-"@foxglove/tsconfig@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@foxglove/tsconfig/-/tsconfig-1.0.0.tgz#bd097ec78c6120e32ec37e71c14fcc9b5cabf9ae"
-  integrity sha512-JeiZ5AvgPE+tIPJZbzmOXD3ADGpv/y98KpF5Sj6AKi1nhWajcUpiER4Sb6lK5EHxlGF5pRGv7K9riKS1rSMXMw==
+"@foxglove/tsconfig@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@foxglove/tsconfig/-/tsconfig-1.1.0.tgz#48c37fffd6f349c3ee08a60fc62ccf636f3b59a6"
+  integrity sha512-qZU4MtXVgPhDBFazSEx7yDEuEg8cPHXFQVhBaUABZkCBdcnEE9sxlgEt0gSikF4fRtY6COGIJPVRflnPJXjJKA==
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"


### PR DESCRIPTION
Disable `composite` build, so that `*.tsbuildinfo` files aren't include in the package archive. This fixes inconsistencies that came from installing directly from a git commit on macOS vs Linux which have different FS case sensitivity.