### PR TITLE
Use cjs for web entry point

### DIFF
--- a/web.d.ts
+++ b/web.d.ts
@@ -1,1 +1,1 @@
-export { default as BlobReader } from "./dist/esm/web/BlobReader";
+export { default as BlobReader } from "./dist/cjs/web/BlobReader";

--- a/web.js
+++ b/web.js
@@ -2,7 +2,7 @@
 // For now we "fake" them by having this top level js file
 // https://nodejs.org/api/packages.html#packages_conditional_exports
 
-const { default: BlobReader } = require("./dist/esm/web/BlobReader");
+const { default: BlobReader } = require("./dist/cjs/web/BlobReader");
 
 module.exports = {
   BlobReader,


### PR DESCRIPTION
Fixes running code in jest that imports the web version, since jest can't handle esm.

We could also make a separate web.cjs and web.mjs entry point if necessary.