### PR TITLE
README: Display correct npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @foxglove/rosbag &nbsp; [![npm version](https://img.shields.io/npm/v/rosbag.svg?style=flat)](https://www.npmjs.com/package/@foxglove/rosbag)
+# @foxglove/rosbag &nbsp; [![npm version](https://img.shields.io/npm/v/@foxglove/rosbag.svg?style=flat)](https://www.npmjs.com/package/@foxglove/rosbag)
 
 `@foxglove/rosbag` is a node.js & browser compatible module for reading [rosbag](http://wiki.ros.org/rosbag) binary data files.
 


### PR DESCRIPTION
The NPM version badge was pointing to the wrong package