### PR TITLE
Add "src" to package.json files entry.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "browser": "dist/esm/index.js",
   "files": [
     "dist",
+    "src",
     "node.d.ts",
     "node.js",
     "web.d.ts",


### PR DESCRIPTION
The generated sourcemaps reference files in the src folder. Without the src
files present, these source maps do not work properly.

Fixes #42