### PR TITLE
Use Blob.arrayBuffer to get the array buffer from a blob

### DIFF
--- a/src/web/BlobReader.ts
+++ b/src/web/BlobReader.ts
@@ -23,26 +23,8 @@ export default class BlobReader implements Filelike {
 
   // read length (bytes) starting from offset (bytes)
   async read(offset: number, length: number): Promise<Uint8Array> {
-    return await new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = function () {
-        reader.onload = null;
-        reader.onerror = null;
-
-        if (reader.result == undefined || !(reader.result instanceof ArrayBuffer)) {
-          reject("Unsupported format for BlobReader");
-          return;
-        }
-
-        resolve(new Uint8Array(reader.result));
-      };
-      reader.onerror = function () {
-        reader.onload = null;
-        reader.onerror = null;
-        reject(reader.error ?? new Error("Unknown FileReader error"));
-      };
-      reader.readAsArrayBuffer(this._blob.slice(offset, offset + length));
-    });
+    const arrBuf = await this._blob.slice(offset, offset + length).arrayBuffer();
+    return new Uint8Array(arrBuf);
   }
 
   // return the size of the file


### PR DESCRIPTION

**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
None

**Description**
<!-- describe what has changed, and motivation behind those changes -->
Rather than the more involved FileReader apis, Blob has an arrayReader method.

This was attempted before - but since jsdom doesn't support the api it was not done. I've polyfilled the test.
https://github.com/foxglove/rosbag/pull/15#discussion_r675957629

<!-- link relevant GitHub issues -->
