### PR TITLE
Add Bag#forwardIterator and Bag#reverseIterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ async function logMessagesFromFooBar() {
 
   await bag.open();
 
-  // read all messages from both the '/foo' and '/bar' topics:
-  await bag.readMessages({ topics: ["/foo", "/bar"] }, (result) => {
+  for await (const result of bag.forwardIterator({ topics: ["/foo", "/bar"] })) {
     // topic is the topic the data record was in
     // in this case it will be either '/foo' or '/bar'
     console.log(result.topic);
@@ -39,7 +38,7 @@ async function logMessagesFromFooBar() {
     // message is the parsed payload
     // this payload will likely differ based on the topic
     console.log(result.message);
-  });
+  }
 }
 
 logMessagesFromFooBar();
@@ -62,9 +61,6 @@ class Bag {
 
   // an array of ChunkInfos describing the chunks within the bag
   chunkInfos: Array<ChunkInfo>,
-
-  // call to consume from the bag - see 'Consuming messages from the bag instance' below
-  readMessages(options: BagOptions, cb: (result: ReadResult) => void) => Promise<void>
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ async function logMessagesFromFooBar() {
 
   await bag.open();
 
-  for await (const result of bag.forwardIterator({ topics: ["/foo", "/bar"] })) {
+  for await (const result of bag.messageIterator({ topics: ["/foo", "/bar"] })) {
     // topic is the topic the data record was in
     // in this case it will be either '/foo' or '/bar'
     console.log(result.topic);
@@ -64,29 +64,10 @@ class Bag {
 }
 ```
 
-### Consuming messages from the bag instance
-
-`bag.readMessages` method returns a `Promise<void>` which resolves when the read operation is completed or rejects in the event of a read error. _During_ the read operation individual `ReadResult` objects are passed to the `callback` supplied to the `open` function. The `callback` may be called multiple times on the same tick as multiple data records can be encoded within a single binary chunk read within the bag reader.
-
 ### BagOptions
 
 ```typescript
-const bagOptions = {
-  // an optional array of topics used to filter down
-  // which data records will be read
-  // the default is all records on all topics
-  topics?: Array<string>,
-
-  // an optional Time instance used to filter data records
-  // to only those which start on or after the given start time
-  // the default is undefined which will apply no filter
-  startTime?: Time,
-
-  // an optional Time instance used to filter data records
-  // to only those which end on or before the given end time
-  // the default is undefined which will apply no filter
-  endTime?: Time,
-
+const options = {
   // decompression callbacks:
   // if your bag is compressed you can supply a callback to decompress it
   // based on the compression type. The callback should accept a buffer of compressed bytes
@@ -99,47 +80,50 @@ const bagOptions = {
     lz4?: (buffer: Uint8Array, uncompressedByteLength: number) => Uint8Array,
   },
 
-  // by default the individual parsed binary messages will be parsed based on their [ROS message definition](http://wiki.ros.org/msg)
-  // if you set noParse to true the read operation will skip the message parsing step
-  noParse?: boolean,
-
-  // Whether the resulting messages should be deeply frozen using Object.freeze(). (default: false)
-  // Useful to make sure your code or libraries doesn't accidentally mutate bag messages.
-  freeze?: boolean,
+  // Toggle the message deserialization behavior. By default, messages are deserialized into javascript objects. You can override this behavior by setting this to `false`.
+  parse?: boolean;
 }
 ```
 
-All options are optional and used to filter down from the sometimes enormous and varied data records in a rosbag. One could omit all options & filter the messages in memory within the `readMessages` callback; however, due to the rosbag format optimizations can be made during reading & parsing which will yield _significant_ performance and memory gains if you specify topics and/or date ranges ahead of time.
+### Consuming messages from the bag instance
 
-### ReadResult
+`bag.messageIterator` method returns an [Async Iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) for messages in the file. Each item is a `MessageEvent`.
+
+### IteratorOptions
 
 ```typescript
-const readResult {
+const options {
+  // an optional array of topics used to filter down
+  // which data records will be read
+  // the default is all records on all topics
+  topics?: Array<string>,
 
+  // an optional Time instance used to filter data records
+  // to only those which start on or after the given start time
+  // the default is undefined which will apply no filter
+  start?: Time,
+}
+```
+
+### MessageEvent
+
+```typescript
+const messageEvent {
   // the topic from which the current record was read
   topic: string,
 
-  // the parsed message contents as a JavaScript object
-  // this can contain nested complex types
-  // and arrays of complex & simple types
-  // this will be undefined if you supply { noParse: true } to `bag.readMessages`
-  message: { [string]: any },
-
-  // a Time instance - the receive time of the message
+  // the receive time of the message
   timestamp: Time
 
   // the raw buffer data from the data record
   // a node.js buffer in node & an array buffer in the browser
   data: Uint8Array,
 
-  // the offset of the chunk being read
-  // starts at 0 and eventually increments to totalChunks
-  // useful for computing read progress as a percentage
-  chunkOffset: number,
-
-  // the total chunks to eventually be consumed
-  // during the current read operation
-  totalChunks: number,
+  // the parsed message contents as a JavaScript object
+  // this can contain nested complex types
+  // and arrays of complex & simple types
+  // If parsing is disabled this field is set to `undefined`
+  message?: { [string]: unknown },
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@foxglove/eslint-plugin": "0.14.0",
     "@foxglove/tsconfig": "1.1.0",
-    "@types/heap": "0.2.28",
     "@types/jest": "27.0.1",
     "@types/node": "16.7.1",
     "@typescript-eslint/eslint-plugin": "4.29.2",

--- a/src/Bag.test.ts
+++ b/src/Bag.test.ts
@@ -41,47 +41,6 @@ async function fullyReadBag<T>(name: string, opts?: ReadOptions): Promise<ReadRe
   return messages;
 }
 
-// fixme - real tests - reuse those below
-/*
-describe("cursor", () => {
-  it("support forward iterator", async () => {
-    const filename = getFixture("example");
-    expect(fs.existsSync(filename)).toBe(true);
-    const bag = await open(filename);
-
-    console.log("start", bag.startTime);
-    console.log("end", bag.endTime);
-
-    if (!bag.startTime) {
-      throw new Error("bag does not have start time");
-    }
-
-    const iterator = bag.forwardIterator({ position: bag.startTime });
-    for await (const result of iterator) {
-      console.log(result);
-    }
-  });
-
-  it("support reverse iterator", async () => {
-    const filename = getFixture("example");
-    expect(fs.existsSync(filename)).toBe(true);
-    const bag = await open(filename);
-
-    console.log("start", bag.startTime);
-    console.log("end", bag.endTime);
-
-    if (!bag.endTime) {
-      throw new Error("bag does not have end time");
-    }
-
-    const iterator = bag.reverseIterator({ position: bag.endTime });
-    for await (const result of iterator) {
-      console.log(result);
-    }
-  });
-});
-*/
-
 describe("Bag", () => {
   it("handles empty and non-existent bags", async () => {
     await expect(open(getFixture("NON_EXISTENT_FILE"))).rejects.toThrow(

--- a/src/Bag.test.ts
+++ b/src/Bag.test.ts
@@ -41,6 +41,59 @@ async function fullyReadBag<T>(name: string, opts?: ReadOptions): Promise<ReadRe
   return messages;
 }
 
+describe.only("cursor", () => {
+  it("support forward iterator", async () => {
+    const filename = getFixture("example");
+    expect(fs.existsSync(filename)).toBe(true);
+    const bag = await open(filename);
+
+    console.log("start", bag.startTime);
+    console.log("end", bag.endTime);
+
+    if (!bag.startTime) {
+      throw new Error("bag does not have start time");
+    }
+
+    const forwardIterator = bag.forwardIterator({ timestamp: bag.startTime });
+
+    let message = await forwardIterator.next();
+    while (message != undefined) {
+      console.log(message);
+
+      // next
+      message = await forwardIterator.next();
+    }
+  });
+
+  it.only("support reverse iterator", async () => {
+    const filename = getFixture("example");
+    expect(fs.existsSync(filename)).toBe(true);
+    const bag = await open(filename);
+
+    console.log("start", bag.startTime);
+    console.log("end", bag.endTime);
+
+    if (!bag.endTime) {
+      throw new Error("bag does not have end time");
+    }
+
+    const iterator = bag.reverseIterator({ timestamp: bag.endTime });
+
+    let message = await iterator.next();
+    //console.log(message);
+
+    //const message2 = await iterator.next();
+    //console.log(message2);
+
+    while (message != undefined) {
+      console.log(message);
+
+      // next
+      message = await iterator.next();
+    }
+  });
+});
+
 describe("basics", () => {
   it("handles empty and non-existent bags", async () => {
     await expect(open(getFixture("NON_EXISTENT_FILE"))).rejects.toThrow(

--- a/src/Bag.test.ts
+++ b/src/Bag.test.ts
@@ -41,7 +41,9 @@ async function fullyReadBag<T>(name: string, opts?: ReadOptions): Promise<ReadRe
   return messages;
 }
 
-describe.only("cursor", () => {
+// fixme - real tests - reuse those below
+/*
+describe("cursor", () => {
   it("support forward iterator", async () => {
     const filename = getFixture("example");
     expect(fs.existsSync(filename)).toBe(true);
@@ -54,18 +56,13 @@ describe.only("cursor", () => {
       throw new Error("bag does not have start time");
     }
 
-    const forwardIterator = bag.forwardIterator({ timestamp: bag.startTime });
-
-    let message = await forwardIterator.next();
-    while (message != undefined) {
-      console.log(message);
-
-      // next
-      message = await forwardIterator.next();
+    const iterator = bag.forwardIterator({ position: bag.startTime });
+    for await (const result of iterator) {
+      console.log(result);
     }
   });
 
-  it.only("support reverse iterator", async () => {
+  it("support reverse iterator", async () => {
     const filename = getFixture("example");
     expect(fs.existsSync(filename)).toBe(true);
     const bag = await open(filename);
@@ -77,24 +74,15 @@ describe.only("cursor", () => {
       throw new Error("bag does not have end time");
     }
 
-    const iterator = bag.reverseIterator({ timestamp: bag.endTime });
-
-    let message = await iterator.next();
-    //console.log(message);
-
-    //const message2 = await iterator.next();
-    //console.log(message2);
-
-    while (message != undefined) {
-      console.log(message);
-
-      // next
-      message = await iterator.next();
+    const iterator = bag.reverseIterator({ position: bag.endTime });
+    for await (const result of iterator) {
+      console.log(result);
     }
   });
 });
+*/
 
-describe("basics", () => {
+describe("Bag", () => {
   it("handles empty and non-existent bags", async () => {
     await expect(open(getFixture("NON_EXISTENT_FILE"))).rejects.toThrow(
       "no such file or directory",
@@ -102,9 +90,7 @@ describe("basics", () => {
     await expect(open(getFixture("empty-file"))).rejects.toThrow("Attempted to read 13 bytes");
     await expect(fullyReadBag("no-messages")).resolves.toEqual([]);
   });
-});
 
-describe("rosbag - high-level api", () => {
   const testNumberOfMessages = (
     name: string,
     expected: number,

--- a/src/Bag.ts
+++ b/src/Bag.ts
@@ -40,8 +40,8 @@ export default class Bag {
   header?: BagHeader;
   connections: Map<number, Connection>;
   chunkInfos: ChunkInfo[] = [];
-  startTime: Time | null | undefined;
-  endTime: Time | null | undefined;
+  startTime?: Time;
+  endTime?: Time;
 
   private bagOpt: BagOpt;
 

--- a/src/Bag.ts
+++ b/src/Bag.ts
@@ -64,12 +64,12 @@ export default class Bag {
     }
   }
 
-  forwardIterator(opt: { timestamp: Time }): ForwardIterator {
-    return new ForwardIterator({ timestamp: opt.timestamp, bag: this });
+  forwardIterator(opt: { timestamp: Time; topics?: string[] }): ForwardIterator {
+    return new ForwardIterator({ timestamp: opt.timestamp, topics: opt.topics, bag: this });
   }
 
-  reverseIterator(opt: { timestamp: Time }): ReverseIterator {
-    return new ReverseIterator({ timestamp: opt.timestamp, bag: this });
+  reverseIterator(opt: { timestamp: Time; topics?: string[] }): ReverseIterator {
+    return new ReverseIterator({ timestamp: opt.timestamp, topics: opt.topics, bag: this });
   }
 
   async readMessages<T = unknown>(

--- a/src/Bag.ts
+++ b/src/Bag.ts
@@ -10,7 +10,9 @@ import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { compare, Time } from "@foxglove/rostime";
 
 import BagReader, { Decompress } from "./BagReader";
+import { ForwardIterator } from "./ForwardIterator";
 import ReadResult from "./ReadResult";
+import { ReverseIterator } from "./ReverseIterator";
 import { BagHeader, ChunkInfo, Connection, MessageData } from "./record";
 import { Filelike } from "./types";
 
@@ -60,6 +62,14 @@ export default class Bag {
       this.startTime = this.chunkInfos[0]!.startTime;
       this.endTime = this.chunkInfos[chunkCount - 1]!.endTime;
     }
+  }
+
+  forwardIterator(opt: { timestamp: Time }): ForwardIterator {
+    return new ForwardIterator({ timestamp: opt.timestamp, bag: this });
+  }
+
+  reverseIterator(opt: { timestamp: Time }): ReverseIterator {
+    return new ReverseIterator({ timestamp: opt.timestamp, bag: this });
   }
 
   async readMessages<T = unknown>(

--- a/src/Bag.ts
+++ b/src/Bag.ts
@@ -9,12 +9,12 @@ import { parse as parseMessageDefinition } from "@foxglove/rosmsg";
 import { MessageReader } from "@foxglove/rosmsg-serialization";
 import { compare, Time } from "@foxglove/rostime";
 
-import BagReader, { Decompress } from "./BagReader";
+import BagReader from "./BagReader";
 import { ForwardIterator } from "./ForwardIterator";
 import ReadResult from "./ReadResult";
 import { ReverseIterator } from "./ReverseIterator";
 import { BagHeader, ChunkInfo, Connection, MessageData } from "./record";
-import { Filelike } from "./types";
+import { Filelike, Decompress } from "./types";
 
 export type ReadOptions = {
   decompress?: Decompress;
@@ -86,7 +86,9 @@ export default class Bag {
     return new ForwardIterator({
       position,
       topics,
-      bag: this,
+      reader: this.reader,
+      chunkInfos: this.chunkInfos,
+      connections: this.connections,
       decompress: this.bagOpt.decompress ?? {},
     });
   }
@@ -100,7 +102,9 @@ export default class Bag {
     return new ReverseIterator({
       position,
       topics,
-      bag: this,
+      reader: this.reader,
+      connections: this.connections,
+      chunkInfos: this.chunkInfos,
       decompress: this.bagOpt.decompress ?? {},
     });
   }

--- a/src/BagReader.ts
+++ b/src/BagReader.ts
@@ -10,19 +10,10 @@ import { compare, isGreaterThan, Time } from "@foxglove/rostime";
 import { extractFields } from "./fields";
 import nmerge from "./nmerge";
 import { Record, BagHeader, Chunk, ChunkInfo, Connection, IndexData, MessageData } from "./record";
-import { Filelike, Constructor } from "./types";
+import type { Filelike, Constructor, Decompress, ChunkReadResult } from "./types";
 
 // Use little endian to read values in dataview
 const LITTLE_ENDIAN = true;
-
-export interface ChunkReadResult {
-  chunk: Chunk;
-  indices: IndexData[];
-}
-
-export type Decompress = {
-  [compression: string]: (buffer: Uint8Array, size: number) => Uint8Array;
-};
 
 const HEADER_READAHEAD = 4096;
 const HEADER_OFFSET = 13;
@@ -96,7 +87,7 @@ export default class BagReader {
       for (let i = 0; i < chunkCount - 1; i++) {
         chunkInfos[i]!.nextChunk = chunkInfos[i + 1];
       }
-      chunkInfos[chunkCount - 1]!.nextChunk = null;
+      chunkInfos[chunkCount - 1]!.nextChunk = undefined;
     }
 
     return { connections, chunkInfos };

--- a/src/BagReader.ts
+++ b/src/BagReader.ts
@@ -15,7 +15,7 @@ import { Filelike, Constructor } from "./types";
 // Use little endian to read values in dataview
 const LITTLE_ENDIAN = true;
 
-interface ChunkReadResult {
+export interface ChunkReadResult {
   chunk: Chunk;
   indices: IndexData[];
 }

--- a/src/BaseIterator.ts
+++ b/src/BaseIterator.ts
@@ -1,0 +1,94 @@
+import type { Time } from "@foxglove/rostime";
+import Heap from "heap";
+
+import { IBagReader } from "./IBagReader";
+import { ChunkInfo, Connection, MessageData } from "./record";
+import type {
+  ChunkReadResult,
+  IteratorConstructorArgs,
+  MessageIterator,
+  MessageEvent,
+  Decompress,
+} from "./types";
+
+type HeapItem = { time: Time; offset: number; chunkReadResult: ChunkReadResult };
+
+export abstract class BaseIterator implements MessageIterator {
+  private connections: Map<number, Connection>;
+  private parse?: IteratorConstructorArgs["parse"];
+
+  protected connectionIds?: Set<number>;
+  protected reader: IBagReader;
+  protected heap: Heap<HeapItem>;
+  protected position: Time;
+  protected decompress: Decompress;
+  protected chunkInfos: ChunkInfo[];
+  protected cachedChunkReadResults = new Map<number, ChunkReadResult>();
+
+  constructor(args: IteratorConstructorArgs, compare: (a: HeapItem, b: HeapItem) => number) {
+    this.connections = args.connections;
+    this.reader = args.reader;
+    this.position = args.position;
+    this.decompress = args.decompress;
+    this.reader = args.reader;
+    this.chunkInfos = args.chunkInfos;
+    this.heap = new Heap(compare);
+
+    // if we want to filter by topic, make a list of connection ids to allow
+    if (args.topics) {
+      const topics = args.topics;
+      this.connectionIds = new Set();
+      for (const [id, connection] of args.connections) {
+        if (topics.includes(connection.topic)) {
+          this.connectionIds.add(id);
+        }
+      }
+    }
+  }
+
+  // Load the next set of messages into the heap
+  protected abstract loadNext(): Promise<void>;
+
+  /**
+   * @returns An AsyncIterator of MessageEvents
+   */
+  async *[Symbol.asyncIterator](): AsyncIterator<MessageEvent> {
+    while (true) {
+      if (!this.heap.front()) {
+        await this.loadNext();
+      }
+
+      const item = this.heap.pop();
+      if (!item) {
+        return;
+      }
+
+      const chunk = item.chunkReadResult.chunk;
+      const messageData = this.reader.readRecordFromBuffer(
+        chunk.data!.subarray(item.offset),
+        chunk.dataOffset!,
+        MessageData,
+      );
+
+      const connection = this.connections.get(messageData.conn);
+      if (!connection) {
+        throw new Error(`Unable to find connection with id ${messageData.conn}`);
+      }
+
+      const { topic } = connection;
+      const { data, time } = messageData;
+      if (!data) {
+        throw new Error(`No data in message for topic: ${topic}`);
+      }
+
+      const event: MessageEvent = {
+        topic,
+        timestamp: time,
+        data,
+        message: this.parse?.(data, connection),
+      };
+
+      yield event;
+    }
+  }
+}

--- a/src/ForwardIterator.test.ts
+++ b/src/ForwardIterator.test.ts
@@ -1,0 +1,296 @@
+import { Time } from "@foxglove/rostime";
+
+import { ForwardIterator } from "./ForwardIterator";
+import { IBagReader } from "./IBagReader";
+import { ChunkInfo, Connection, IndexData, MessageData, Record } from "./record";
+import { ChunkReadResult, Constructor } from "./types";
+
+type EnhancedChunkInfo = ChunkInfo & {
+  messages: FixtureMessage[];
+};
+
+type FixtureMessage = {
+  connection: number;
+  time: number;
+  value: number;
+};
+
+type FixtureInput = {
+  chunks: {
+    messages: FixtureMessage[];
+  }[];
+};
+
+type FixtureOutput = {
+  connections: Map<number, Connection>;
+  chunkInfos: ChunkInfo[];
+  reader: IBagReader;
+  expectedMessages: { conn: number; time: Time; value: number }[];
+};
+
+class FakeBagReader implements IBagReader {
+  private chunks: EnhancedChunkInfo[];
+
+  constructor(chunks: EnhancedChunkInfo[]) {
+    this.chunks = chunks;
+  }
+
+  async readChunk(chunkInfo: ChunkInfo): Promise<ChunkReadResult> {
+    const chunk = this.chunks[chunkInfo.chunkPosition];
+    if (!chunk) {
+      throw new Error(`No chunk for position ${chunkInfo.chunkPosition}`);
+    }
+
+    const indexByConnId = new Map<number, IndexData>();
+
+    const offsets = [];
+    let offset = 0;
+    for (const msg of chunk.messages) {
+      let indexData = indexByConnId.get(msg.connection);
+      if (!indexData) {
+        indexData = {
+          ver: 1,
+          conn: msg.connection,
+          count: 1,
+          indices: [],
+          parseData: () => {},
+        };
+        indexByConnId.set(msg.connection, indexData);
+      }
+
+      indexData.indices?.push({
+        time: {
+          sec: 0,
+          nsec: msg.time,
+        },
+        offset,
+      });
+
+      offsets.push(offset);
+      offset += 1;
+    }
+
+    return {
+      chunk: {
+        compression: "",
+        size: chunk.messages.length,
+        data: new Uint8Array(offsets),
+        dataOffset: chunkInfo.chunkPosition,
+        parseData: () => {},
+      },
+      indices: Array.from(indexByConnId.values()),
+    };
+  }
+
+  readRecordFromBuffer<T extends Record>(
+    buffer: Uint8Array,
+    fileOffset: number,
+    cls: Constructor<T> & { opcode: number },
+  ): T {
+    const chunk = this.chunks[fileOffset];
+
+    const message = chunk?.messages[buffer[0]!];
+
+    const out = new cls({
+      conn: new Uint8Array([0, 0, 0, message!.connection]),
+      time: new Uint8Array([0, 0, 0, 0, message!.time, 0, 0, 0]),
+    });
+
+    // patch value onto our output to compare with expected data
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (out as any).value = message?.value;
+
+    return out;
+  }
+}
+
+function generateFixtures(input: FixtureInput): FixtureOutput {
+  const connections: FixtureOutput["connections"] = new Map();
+  const chunkInfos: EnhancedChunkInfo[] = [];
+  const expectedMessages: FixtureMessage[] = [];
+
+  for (const chunk of input.chunks) {
+    let startNs = Infinity;
+    let endNs = 0;
+    for (const msg of chunk.messages) {
+      startNs = Math.min(msg.time, startNs);
+      endNs = Math.max(msg.time, endNs);
+
+      const connId = msg.connection;
+      connections.set(connId, {
+        conn: connId,
+        topic: `/${connId}`,
+        messageDefinition: `${connId}`,
+        parseData: () => {},
+      });
+
+      expectedMessages.push(msg);
+    }
+
+    const idx = chunkInfos.length;
+    chunkInfos.push({
+      ver: 1,
+      chunkPosition: idx,
+      startTime: { sec: 0, nsec: startNs },
+      endTime: { sec: 0, nsec: endNs },
+      count: 1,
+      connections: [],
+      parseData: () => {},
+      messages: chunk.messages,
+    });
+  }
+
+  expectedMessages.sort((a, b) => a.time - b.time);
+
+  const reader = new FakeBagReader(chunkInfos);
+  return {
+    connections,
+    chunkInfos,
+    reader,
+    expectedMessages: expectedMessages.map((msg) => {
+      return {
+        conn: msg.connection,
+        time: { sec: 0, nsec: msg.time },
+        value: msg.value,
+      };
+    }),
+  };
+}
+
+async function consumeMessages(iterator: ForwardIterator): Promise<MessageData[]> {
+  const data = [];
+  for await (const msg of iterator) {
+    data.push(msg);
+  }
+  return data;
+}
+
+describe("ForwardIterator", () => {
+  it("should iterate empty bag", async () => {
+    const iterator = new ForwardIterator({
+      connections: new Map(),
+      chunkInfos: [],
+      decompress: {},
+      reader: new FakeBagReader([]),
+      position: { sec: 0, nsec: 0 },
+    });
+
+    const messages = await consumeMessages(iterator);
+    expect(messages).toEqual([]);
+  });
+
+  it("should iterate through a chunk", async () => {
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 0,
+              value: 2,
+            },
+            {
+              connection: 0,
+              time: 1,
+              value: 3,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ForwardIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 0 },
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(expectedMessages);
+  });
+
+  it("should ignore messages before position", async () => {
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 1,
+              value: 2,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ForwardIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 1 },
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(expectedMessages.filter((msg) => msg.time.nsec >= 1));
+  });
+
+  it("should read multiple overlapping chunks", async () => {
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 1,
+              value: 2,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 3,
+            },
+            {
+              connection: 0,
+              time: 1,
+              value: 4,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ForwardIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 0 },
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(expectedMessages);
+  });
+});

--- a/src/ForwardIterator.ts
+++ b/src/ForwardIterator.ts
@@ -1,0 +1,111 @@
+import { compare, Time, add as addTime } from "@foxglove/rostime";
+import Heap from "heap";
+
+import type Bag from "./Bag";
+import { ChunkReadResult } from "./BagReader";
+import { MessageData } from "./record";
+
+class ForwardIterator {
+  private bag: Bag;
+  private heap: Heap<{ time: Time; offset: number; chunkReadResult: ChunkReadResult }>;
+  private currentTimestamp: Time;
+
+  constructor(opt: { timestamp: Time; bag: Bag }) {
+    this.currentTimestamp = opt.timestamp;
+    this.bag = opt.bag;
+
+    this.heap = new Heap((a, b) => {
+      return compare(a.time, b.time);
+    });
+  }
+
+  async loadNext(): Promise<void> {
+    const stamp = this.currentTimestamp;
+
+    const chunkInfos = this.bag.chunkInfos.filter((info) => {
+      return compare(info.startTime, stamp) <= 0 && compare(stamp, info.endTime) <= 0;
+    });
+
+    if (chunkInfos.length === 0) {
+      return;
+    }
+
+    // `T` is the current timestamp.
+    // Here we see some possible chunk ranges.
+    // A [------T-----]
+    // B      [----------]
+    // C              [-----]
+    // D          [------]
+    // E         [---]
+    //
+    // A & B include T
+    // To determine the maximum time we can iterate to until we need to load more.
+    // We take all the earliest end stamp (TE) of the matching chunks (A & B)
+    // We find all other chunks where their start time is between T and TE
+    // The earliest of these start times is the final TE
+
+    // Get the earliest end time across all matching chunks
+    let end = chunkInfos[0]!.endTime;
+    for (const info of chunkInfos) {
+      if (compare(info.endTime, end) < 0) {
+        end = info.endTime;
+      }
+    }
+
+    // fixme - we want end to be 1 nanosecond after that?
+    // otherwise we are setting the same end
+    end = addTime(end, { sec: 0, nsec: 1 });
+
+    // All chunks with start time between stamp and end
+    const terminalChunks = this.bag.chunkInfos.filter((info) => {
+      return compare(stamp, info.startTime) < 0 && compare(info.startTime, end) < 0;
+    });
+
+    // get the earliest of those start times as the new end
+    for (const info of terminalChunks) {
+      if (compare(info.startTime, end) < 0) {
+        end = info.startTime;
+      }
+    }
+
+    this.currentTimestamp = end;
+
+    const heap = this.heap;
+    for (const chunkInfo of chunkInfos) {
+      const result = await this.bag.reader.readChunk(chunkInfo, {});
+
+      for (const indexData of result.indices) {
+        for (const indexEntry of indexData.indices ?? []) {
+          // skip any time that is before our current timestamp or after end, we will never iterate to those
+          if (compare(indexEntry.time, stamp) < 0 && compare(indexEntry.time, end) > 0) {
+            continue;
+          }
+          heap.push({ time: indexEntry.time, offset: indexEntry.offset, chunkReadResult: result });
+        }
+      }
+    }
+  }
+
+  async next(): Promise<MessageData | undefined> {
+    if (!this.heap.front()) {
+      // there are no more items, load more
+      await this.loadNext();
+    }
+
+    const item = this.heap.pop();
+    if (!item) {
+      return undefined;
+    }
+
+    const chunk = item.chunkReadResult.chunk;
+    const read = this.bag.reader.readRecordFromBuffer(
+      chunk.data!.subarray(item.offset),
+      chunk.dataOffset!,
+      MessageData,
+    );
+
+    return read;
+  }
+}
+
+export { ForwardIterator };

--- a/src/IBagReader.ts
+++ b/src/IBagReader.ts
@@ -1,0 +1,18 @@
+import type { ChunkInfo, Record } from "./record";
+import type { Decompress, Constructor, ChunkReadResult } from "./types";
+
+export interface IBagReader {
+  /**
+   * reads a single chunk record && its index records given a chunkInfo
+   */
+  readChunk(chunkInfo: ChunkInfo, decompress: Decompress): Promise<ChunkReadResult>;
+
+  /**
+   * Read an individaul record from a buffer
+   */
+  readRecordFromBuffer<T extends Record>(
+    buffer: Uint8Array,
+    fileOffset: number,
+    cls: Constructor<T> & { opcode: number },
+  ): T;
+}

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -1,0 +1,109 @@
+import { compare, Time, subtract as subTime } from "@foxglove/rostime";
+import Heap from "heap";
+
+import type Bag from "./Bag";
+import { ChunkReadResult } from "./BagReader";
+import { MessageData } from "./record";
+
+class ReverseIterator {
+  private bag: Bag;
+  private heap: Heap<{ time: Time; offset: number; chunkReadResult: ChunkReadResult }>;
+  private currentTimestamp: Time;
+
+  constructor(opt: { timestamp: Time; bag: Bag }) {
+    this.currentTimestamp = opt.timestamp;
+    this.bag = opt.bag;
+
+    // Sort by largest timestamp first
+    this.heap = new Heap((a, b) => {
+      return compare(b.time, a.time);
+    });
+  }
+
+  async loadNext(): Promise<void> {
+    const stamp = this.currentTimestamp;
+
+    // Get the chunks that contain our stamp
+    const chunkInfos = this.bag.chunkInfos.filter((info) => {
+      return compare(info.startTime, stamp) <= 0 && compare(stamp, info.endTime) <= 0;
+    });
+
+    if (chunkInfos.length === 0) {
+      return;
+    }
+
+    // `T` is the current timestamp.
+    // Here we see some possible chunk ranges.
+    // A          [------T-----]
+    // B        [----------]
+    // C      [-----]
+    // D [------]
+    // E           [---]
+    //
+    // A & B include T
+
+    // Get the latest start time across all matching chunks
+    let start = chunkInfos[0]!.startTime;
+    for (const info of chunkInfos) {
+      if (compare(info.startTime, start) > 0) {
+        start = info.startTime;
+      }
+    }
+
+    // fixme - we want end to be 1 nanosecond after that?
+    // otherwise we are setting the same end
+    start = subTime(start, { sec: 0, nsec: 1 });
+
+    // All chunks with end time between start and stamp
+    const terminalChunks = this.bag.chunkInfos.filter((info) => {
+      return compare(start, info.endTime) < 0 && compare(info.endTime, stamp) < 0;
+    });
+
+    // get the latest of those end times as the new start
+    for (const info of terminalChunks) {
+      if (compare(start, info.endTime) < 0) {
+        start = info.startTime;
+      }
+    }
+
+    this.currentTimestamp = start;
+
+    const heap = this.heap;
+    for (const chunkInfo of chunkInfos) {
+      const result = await this.bag.reader.readChunk(chunkInfo, {});
+
+      for (const indexData of result.indices) {
+        for (const indexEntry of indexData.indices ?? []) {
+          // skip any time that is before our current timestamp or after end, we will never iterate to those
+          if (compare(indexEntry.time, start) < 0 && compare(indexEntry.time, stamp) > 0) {
+            continue;
+          }
+          heap.push({ time: indexEntry.time, offset: indexEntry.offset, chunkReadResult: result });
+        }
+      }
+    }
+  }
+
+  async next(): Promise<MessageData | undefined> {
+    if (!this.heap.front()) {
+      // there are no more items, load more
+      await this.loadNext();
+    }
+
+    const item = this.heap.pop();
+    if (!item) {
+      return undefined;
+    }
+
+    const chunk = item.chunkReadResult.chunk;
+    const read = this.bag.reader.readRecordFromBuffer(
+      chunk.data!.subarray(item.offset),
+      chunk.dataOffset!,
+      MessageData,
+    );
+
+    return read;
+  }
+}
+
+export { ReverseIterator };

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -3,16 +3,28 @@ import Heap from "heap";
 
 import type Bag from "./Bag";
 import { ChunkReadResult } from "./BagReader";
-import { MessageData } from "./record";
+import { ChunkInfo, MessageData } from "./record";
 
 class ReverseIterator {
   private bag: Bag;
+  private connectionIds?: Set<number>;
   private heap: Heap<{ time: Time; offset: number; chunkReadResult: ChunkReadResult }>;
   private currentTimestamp: Time;
 
-  constructor(opt: { timestamp: Time; bag: Bag }) {
+  constructor(opt: { timestamp: Time; bag: Bag; topics?: string[] }) {
     this.currentTimestamp = opt.timestamp;
     this.bag = opt.bag;
+
+    // if we want to filter by topic, make a list of connection ids to allow
+    if (opt.topics) {
+      const topics = opt.topics;
+      this.connectionIds = new Set();
+      for (const [id, connection] of this.bag.connections) {
+        if (topics.includes(connection.topic)) {
+          this.connectionIds.add(id);
+        }
+      }
+    }
 
     // Sort by largest timestamp first
     this.heap = new Heap((a, b) => {
@@ -23,13 +35,56 @@ class ReverseIterator {
   async loadNext(): Promise<void> {
     const stamp = this.currentTimestamp;
 
+    // These are all chunks that contain our connections
+    let candidateChunkInfos = this.bag.chunkInfos;
+
+    const connectionIds = this.connectionIds;
+    if (connectionIds) {
+      candidateChunkInfos = candidateChunkInfos.filter((info) => {
+        return info.connections.find((conn) => {
+          return connectionIds.has(conn.conn);
+        });
+      });
+    }
+
+    if (candidateChunkInfos.length === 0) {
+      return;
+    }
+
     // Get the chunks that contain our stamp
-    const chunkInfos = this.bag.chunkInfos.filter((info) => {
+    let chunkInfos = candidateChunkInfos.filter((info) => {
+      // If we are filtering on connection ids, only include the chunks that have our connection
       return compare(info.startTime, stamp) <= 0 && compare(stamp, info.endTime) <= 0;
     });
 
+    // fixme - so no chunk contains our stamp
+    // get the oldest end time that is before the stamp
+
     if (chunkInfos.length === 0) {
-      return;
+      // There are no chunks that contain our stamp
+      // Get the oldest chunk right before our stamp
+      // fixme - what if two chunks have the same end time
+      // we should keep both
+      const previous = candidateChunkInfos.reduce((prev: ChunkInfo | undefined, info) => {
+        if (!prev) {
+          if (compare(info.endTime, stamp) < 0) {
+            return info;
+          }
+          return undefined;
+        }
+
+        if (compare(info.endTime, prev.endTime) < 0) {
+          return prev;
+        }
+
+        return info;
+      }, undefined);
+
+      if (!previous) {
+        return;
+      }
+
+      chunkInfos = [previous];
     }
 
     // `T` is the current timestamp.
@@ -55,7 +110,7 @@ class ReverseIterator {
     start = subTime(start, { sec: 0, nsec: 1 });
 
     // All chunks with end time between start and stamp
-    const terminalChunks = this.bag.chunkInfos.filter((info) => {
+    const terminalChunks = candidateChunkInfos.filter((info) => {
       return compare(start, info.endTime) < 0 && compare(info.endTime, stamp) < 0;
     });
 
@@ -73,6 +128,9 @@ class ReverseIterator {
       const result = await this.bag.reader.readChunk(chunkInfo, {});
 
       for (const indexData of result.indices) {
+        if (this.connectionIds && !this.connectionIds.has(indexData.conn)) {
+          continue;
+        }
         for (const indexEntry of indexData.indices ?? []) {
           // skip any time that is before our current timestamp or after end, we will never iterate to those
           if (compare(indexEntry.time, start) < 0 && compare(indexEntry.time, stamp) > 0) {

--- a/src/__snapshots__/Bag.test.ts.snap
+++ b/src/__snapshots__/Bag.test.ts.snap
@@ -30,34 +30,3 @@ Record {
   ],
 }
 `;
-
-exports[`rosbag - high-level api reads correct fields on /tf message 1`] = `
-Record {
-  "transforms": Array [
-    Object {
-      "child_frame_id": "turtle2",
-      "header": Object {
-        "frame_id": "world",
-        "seq": 0,
-        "stamp": Object {
-          "nsec": 56065082,
-          "sec": 1396293888,
-        },
-      },
-      "transform": Object {
-        "rotation": Object {
-          "w": 1,
-          "x": 0,
-          "y": 0,
-          "z": 0,
-        },
-        "translation": Object {
-          "x": 4,
-          "y": 9.088889122009277,
-          "z": 0,
-        },
-      },
-    },
-  ],
-}
-`;

--- a/src/__snapshots__/Bag.test.ts.snap
+++ b/src/__snapshots__/Bag.test.ts.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Bag reads correct fields on /tf message 1`] = `
+Record {
+  "transforms": Array [
+    Object {
+      "child_frame_id": "turtle2",
+      "header": Object {
+        "frame_id": "world",
+        "seq": 0,
+        "stamp": Object {
+          "nsec": 56065082,
+          "sec": 1396293888,
+        },
+      },
+      "transform": Object {
+        "rotation": Object {
+          "w": 1,
+          "x": 0,
+          "y": 0,
+          "z": 0,
+        },
+        "translation": Object {
+          "x": 4,
+          "y": 9.088889122009277,
+          "z": 0,
+        },
+      },
+    },
+  ],
+}
+`;
+
 exports[`rosbag - high-level api reads correct fields on /tf message 1`] = `
 Record {
   "transforms": Array [

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -1,0 +1,74 @@
+import lz4 from "lz4js";
+
+import { Bag } from "./index";
+import { FileReader } from "./node";
+
+const bagFilePath = "/Users/roman/Downloads/nuScenes-v1.0-mini-scene-0061.bag";
+
+const decompress = {
+  lz4: (buffer: Uint8Array) => lz4.decompress(buffer),
+};
+
+async function readMessages() {
+  const reader = new FileReader(bagFilePath);
+  const bag = new Bag(reader);
+  await bag.open();
+
+  const start = performance.now();
+  let count = 0;
+  await bag.readMessages({ noParse: true, decompress }, (result) => {
+    // no-op
+    count += 1;
+    void result;
+  });
+  const end = performance.now();
+  console.log(`[read messages] (${count}) duration ms: ${end - start}`);
+  await reader.close();
+}
+
+async function forwardIter() {
+  const reader = new FileReader(bagFilePath);
+  const bag = new Bag(reader, { decompress });
+  await bag.open();
+
+  const start = performance.now();
+  const iter = bag.messageIterator();
+
+  let count = 0;
+  for await (const msg of iter) {
+    count += 1;
+    void msg;
+  }
+  const end = performance.now();
+  console.log(`[forward iter] (${count}) duration ms: ${end - start}`);
+  await reader.close();
+}
+
+async function reverseIter() {
+  const reader = new FileReader(bagFilePath);
+  const bag = new Bag(reader, { decompress });
+  await bag.open();
+
+  const start = performance.now();
+  const iter = bag.messageIterator({ reverse: true });
+
+  let count = 0;
+  for await (const msg of iter) {
+    count += 1;
+    void msg;
+  }
+  const end = performance.now();
+  console.log(`[reverse iter] (${count}) duration ms: ${end - start}`);
+  await reader.close();
+}
+
+async function main() {
+  await readMessages();
+  //await readMessages();
+  await forwardIter();
+  //await forwardIter();
+  await reverseIter();
+  //await reverseIter();
+}
+
+void main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ import Bag from "./Bag";
 
 export type { Filelike } from "./types";
 export { Bag };
+
+export { MessageData } from "./record";

--- a/src/nmerge.ts
+++ b/src/nmerge.ts
@@ -23,10 +23,10 @@ function nmerge<T>(key: (a: T, b: T) => number, ...iterables: Array<Iterator<T>>
       if (heap.empty()) {
         return { done: true, value: undefined };
       }
-      const { i } = heap.front();
+      const { i } = heap.front()!;
       const next = iterables[i]!.next();
       if (next.done === true) {
-        return { value: heap.pop().value, done: false };
+        return { value: heap.pop()!.value, done: false };
       }
       return { value: heap.replace({ i, value: next.value }).value, done: false };
     },

--- a/src/record.ts
+++ b/src/record.ts
@@ -88,12 +88,12 @@ export class Connection extends Record {
   static opcode = 7;
   conn: number;
   topic: string;
-  type: string | null | undefined;
-  md5sum: string | null | undefined;
+  type?: string;
+  md5sum?: string;
   messageDefinition: string;
-  callerid: string | null | undefined;
-  latching: boolean | null | undefined;
-  reader: MessageReader | null | undefined;
+  callerid?: string;
+  latching?: boolean;
+  reader?: MessageReader;
 
   constructor(fields: { [key: string]: Uint8Array }) {
     super();
@@ -170,7 +170,7 @@ export class ChunkInfo extends Record {
   endTime: Time;
   count: number;
   connections: Array<{ conn: number; count: number }> = [];
-  nextChunk: ChunkInfo | null | undefined;
+  nextChunk?: ChunkInfo;
 
   constructor(fields: { [key: string]: Uint8Array }) {
     super();

--- a/src/test_support/iterator.ts
+++ b/src/test_support/iterator.ts
@@ -1,0 +1,158 @@
+import { IBagReader } from "../IBagReader";
+import { ChunkInfo, Connection, IndexData, Record } from "../record";
+import { ChunkReadResult, Constructor, MessageEvent, MessageIterator } from "../types";
+
+export type EnhancedChunkInfo = ChunkInfo & {
+  messages: FixtureMessage[];
+};
+
+export type FixtureMessage = {
+  connection: number;
+  time: number;
+  value: number;
+};
+
+export type FixtureInput = {
+  chunks: {
+    messages: FixtureMessage[];
+  }[];
+};
+
+export type FixtureOutput = {
+  connections: Map<number, Connection>;
+  chunkInfos: ChunkInfo[];
+  reader: IBagReader;
+  expectedMessages: MessageEvent[];
+};
+
+export class FakeBagReader implements IBagReader {
+  private chunks: EnhancedChunkInfo[];
+
+  constructor(chunks: EnhancedChunkInfo[]) {
+    this.chunks = chunks;
+  }
+
+  async readChunk(chunkInfo: ChunkInfo): Promise<ChunkReadResult> {
+    const chunk = this.chunks[chunkInfo.chunkPosition];
+    if (!chunk) {
+      throw new Error(`No chunk for position ${chunkInfo.chunkPosition}`);
+    }
+
+    const indexByConnId = new Map<number, IndexData>();
+
+    const offsets = [];
+    let offset = 0;
+    for (const msg of chunk.messages) {
+      let indexData = indexByConnId.get(msg.connection);
+      if (!indexData) {
+        indexData = {
+          ver: 1,
+          conn: msg.connection,
+          count: 1,
+          indices: [],
+          parseData: () => {},
+        };
+        indexByConnId.set(msg.connection, indexData);
+      }
+
+      indexData.indices?.push({
+        time: {
+          sec: 0,
+          nsec: msg.time,
+        },
+        offset,
+      });
+
+      offsets.push(offset);
+      offset += 1;
+    }
+
+    return {
+      chunk: {
+        compression: "",
+        size: chunk.messages.length,
+        data: new Uint8Array(offsets),
+        dataOffset: chunkInfo.chunkPosition,
+        parseData: () => {},
+      },
+      indices: Array.from(indexByConnId.values()),
+    };
+  }
+
+  readRecordFromBuffer<T extends Record>(
+    buffer: Uint8Array,
+    fileOffset: number,
+    cls: Constructor<T> & { opcode: number },
+  ): T {
+    const chunk = this.chunks[fileOffset]!;
+    const message = chunk.messages[buffer[0]!]!;
+
+    const out = new cls({
+      conn: new Uint8Array([0, 0, 0, message.connection]),
+      time: new Uint8Array([0, 0, 0, 0, message.time, 0, 0, 0]),
+    });
+
+    out.parseData(new Uint8Array([message.value]));
+    return out;
+  }
+}
+
+export function generateFixtures(input: FixtureInput): FixtureOutput {
+  const connections: FixtureOutput["connections"] = new Map();
+  const chunkInfos: EnhancedChunkInfo[] = [];
+  const expectedMessages: MessageEvent[] = [];
+
+  for (const chunk of input.chunks) {
+    let startNs = Infinity;
+    let endNs = 0;
+    for (const msg of chunk.messages) {
+      startNs = Math.min(msg.time, startNs);
+      endNs = Math.max(msg.time, endNs);
+
+      const connId = msg.connection;
+      const topic = `/${connId}`;
+      connections.set(connId, {
+        conn: connId,
+        topic,
+        messageDefinition: `${connId}`,
+        parseData: () => {},
+      });
+
+      expectedMessages.push({
+        topic,
+        timestamp: { sec: 0, nsec: msg.time },
+        data: new Uint8Array([msg.value]),
+      });
+    }
+
+    const idx = chunkInfos.length;
+    chunkInfos.push({
+      ver: 1,
+      chunkPosition: idx,
+      startTime: { sec: 0, nsec: startNs },
+      endTime: { sec: 0, nsec: endNs },
+      count: 1,
+      connections: [],
+      parseData: () => {},
+      messages: chunk.messages,
+    });
+  }
+
+  expectedMessages.sort((a, b) => a.timestamp.nsec - b.timestamp.nsec);
+
+  const reader = new FakeBagReader(chunkInfos);
+  return {
+    connections,
+    chunkInfos,
+    reader,
+    expectedMessages,
+  };
+}
+
+export async function consumeMessages(iterator: MessageIterator): Promise<MessageEvent[]> {
+  const data = [];
+  for await (const msg of iterator) {
+    data.push(msg);
+  }
+  return data;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,11 @@
 // found in the LICENSE file in the root directory of this source tree.
 // You may not use this file except in compliance with the License.
 
+import type { Time } from "@foxglove/rostime";
+
+import type { IBagReader } from "./IBagReader";
+import type { Chunk, ChunkInfo, Connection, IndexData } from "./record";
+
 export type RawFields = { [k: string]: Uint8Array };
 
 export interface Constructor<T> {
@@ -15,3 +20,22 @@ export interface Filelike {
   read(offset: number, length: number): Promise<Uint8Array>;
   size(): number;
 }
+
+export type Decompress = {
+  [compression: string]: (buffer: Uint8Array, size: number) => Uint8Array;
+};
+
+export type ChunkReadResult = {
+  chunk: Chunk;
+  indices: IndexData[];
+};
+
+export type IteratorConstructorArgs = {
+  position: Time;
+  connections: Map<number, Connection>;
+  chunkInfos: ChunkInfo[];
+  reader: IBagReader;
+  decompress: Decompress;
+
+  topics?: string[];
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,4 +38,20 @@ export type IteratorConstructorArgs = {
   decompress: Decompress;
 
   topics?: string[];
+  parse?: (data: Uint8Array, connection: Connection) => unknown;
+};
+
+export type MessageEvent = {
+  topic: string;
+  timestamp: Time;
+  data: Uint8Array;
+
+  message?: unknown;
+};
+
+export type MessageIterator = {
+  /**
+   * @returns An AsyncIterator for serialized message data from the forward iterator
+   */
+  [Symbol.asyncIterator](): AsyncIterator<MessageEvent>;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@foxglove/tsconfig/base",
-  "include": ["./src/**/*", "./typings/*.d.ts"],
+  "include": ["./src/**/*", "./typings/*.d.ts", "*.d.ts"],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/esm",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@foxglove/tsconfig/base",
-  "include": ["./src/**/*", "*.d.ts"],
+  "include": ["./src/**/*", "./typings/*.d.ts"],
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/esm",

--- a/typings/heap/index.d.ts
+++ b/typings/heap/index.d.ts
@@ -1,0 +1,83 @@
+// Patched definitions from DefinitelyTyped
+//
+// Upstream definitions by: Ryan McNamara <https://github.com/ryan10132>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+// Project: https://github.com/qiao/heap.js
+
+declare module "heap" {
+  class Heap<T> {
+    // Constructor
+
+    constructor(cmp?: (a: T, b: T) => number);
+
+    // Instance Methods
+
+    // Push item onto heap.
+    push(item: T): void;
+    insert(item: T): void;
+
+    // Pop the smallest item off the heap and return it.
+    pop(): T | undefined;
+
+    // Return the smallest item of the heap.
+    peek(): T | undefined;
+    top(): T | undefined;
+    front(): T | undefined;
+
+    // Pop and return the current smallest value, and add the new item.
+    // This is more efficient than pop() followed by push(), and can be more appropriate when using a fixed size heap.
+    // Note that the value returned may be larger than item!
+    replace(item: T): T;
+
+    // Fast version of a push followed by a pop.
+    pushpop(item: T): T;
+
+    // Rebuild the heap. This method may come handy when the priority of the internal data is being modified.
+    heapify(): void;
+
+    // Update the position of the given item in the heap. This function should be called every time the item is being modified.
+    updateItem(item: T): void;
+
+    // Determine whether the heap is empty.
+    empty(): boolean;
+
+    // Get the number of elements stored in the heap.
+    size(): number;
+
+    // Return the array representation of the heap. (note: the array is a shallow copy of the heap's internal nodes)
+    toArray(): T[];
+
+    // Return a clone of the heap. (note: the internal data is a shallow copy of the original one)
+    clone(): Heap<T>;
+    copy(): Heap<T>;
+
+    // Static Methods
+
+    // Push item onto array, maintaining the heap invariant.
+    static push<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): void;
+
+    // Pop the smallest item off the array, maintaining the heap invariant.
+    static pop<T>(array: T[], cmp?: (a: T, b: T) => number): T;
+
+    // Pop and return the current smallest value, and add the new item.
+    // This is more efficient than heappop() followed by heappush(), and can be more appropriate when using a fixed size heap. Note that the value returned may be larger than item!
+    static replace<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): T;
+
+    // Fast version of a heappush followed by a heappop.
+    static pushpop<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): T;
+
+    // Build the heap.
+    static heapify<T>(array: T[], cmp?: (a: T, b: T) => number): Heap<T>;
+
+    // Update the position of the given item in the heap. This function should be called every time the item is being modified.
+    static updateItem<T>(array: T[], item: T, cmp?: (a: T, b: T) => number): void;
+
+    // Find the n largest elements in a dataset.
+    static nlargest<T>(array: T[], n: number, cmp?: (a: T, b: T) => number): T[];
+
+    // Find the n smallest elements in a dataset.
+    static nsmallest<T>(array: T[], n: number, cmp?: (a: T, b: T) => number): T[];
+  }
+
+  export = Heap;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -632,11 +632,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/heap@0.2.28":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@types/heap/-/heap-0.2.28.tgz#c4247fae0e438c76ae05194c4b87cd5c4e859a7d"
-  integrity sha1-xCR/rg5DjHauBRlMS4fNXE6Fmn0=
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"


### PR DESCRIPTION
**Public-Facing Changes**
<!-- describe any changes to the public interface or APIs, or write "None" -->
This change introduces two new methods to the `Bag` class. `forwardIterator` and `reverseIterator`. These methods return an instances of a class with a `Symbol.AsyncIterator`. This iterator moves through the file message-by-message in forward receiveTime or reverse receive time order respectively. Each method accepts options to limit the iteration to specific topics or start at a specific position.

The README is updated with a code example which replaces the previous `readMessages` api. This change marks the `readMessages` api as deprecated in favor of the new iterator api.

The motivation for this change comes from needing a way to obtain the "latest" message on a topic without knowing when that message occurred. The existing `readMessage` api could not support this since it relied on the caller providing a start/end range for message reading.

----
Here is an example Studio player which makes use of forward iterators during playback and preloading, and reverse iterators during seek to "backfill" the last message on all subscribed topics.

https://github.com/foxglove/studio/pull/2915