### PR TITLE
Fix forward and reverse iterator when starting in middle of chunk

### DIFF
--- a/src/ForwardIterator.test.ts
+++ b/src/ForwardIterator.test.ts
@@ -129,4 +129,61 @@ describe("ForwardIterator", () => {
     const actualMessages = await consumeMessages(iterator);
     expect(actualMessages).toEqual(expectedMessages);
   });
+
+  // Test when the there is a chunk with messages before and after the position BUT
+  // The messages we want are before the position.
+  //
+  // [AABB][AABB]
+  //     ^
+  it("should iterate when messages are before position and after", async () => {
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 1,
+              value: 2,
+            },
+            {
+              connection: 1,
+              time: 2,
+              value: 3,
+            },
+            {
+              connection: 1,
+              time: 3,
+              value: 4,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 4,
+              value: 5,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ForwardIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 3 },
+      topics: ["/0"],
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(expectedMessages.filter((msg) => msg.timestamp.nsec >= 4));
+  });
 });

--- a/src/ForwardIterator.test.ts
+++ b/src/ForwardIterator.test.ts
@@ -131,7 +131,7 @@ describe("ForwardIterator", () => {
   });
 
   // Test when the there is a chunk with messages before and after the position BUT
-  // The messages we want are before the position.
+  // the messages we want are before our position in the chunk so we need the next chunk.
   //
   // [AABB][AABB]
   //     ^

--- a/src/ForwardIterator.ts
+++ b/src/ForwardIterator.ts
@@ -1,90 +1,82 @@
 import { compare, add as addTime } from "@foxglove/rostime";
+import Heap from "heap";
 
 import { BaseIterator } from "./BaseIterator";
+import { ChunkInfo } from "./record";
 import { IteratorConstructorArgs, ChunkReadResult } from "./types";
 
 export class ForwardIterator extends BaseIterator {
+  private remainingChunkInfos: (ChunkInfo | undefined)[];
+
   constructor(args: IteratorConstructorArgs) {
     // Sort by smallest timestamp first
     super(args, (a, b) => {
       return compare(a.time, b.time);
     });
-  }
-
-  protected override async loadNext(): Promise<void> {
-    let stamp = this.position;
 
     // These are all chunks that we can consider for iteration.
     // Only consider chunks with an endTime after or equal to our position.
     // Chunks before our position are not part of forward iteration.
-    let candidateChunkInfos = this.chunkInfos.filter((info) => {
-      return compare(info.endTime, stamp) >= 0;
+    this.chunkInfos = this.chunkInfos.filter((info) => {
+      return compare(info.endTime, this.position) >= 0;
     });
 
-    if (candidateChunkInfos.length === 0) {
+    // The chunk info heap sorts chunk infos by increasing start time
+    const chunkInfoHeap = new Heap<ChunkInfo>((a, b) => {
+      return compare(a.startTime, b.startTime);
+    });
+
+    for (const info of this.chunkInfos) {
+      chunkInfoHeap.insert(info);
+    }
+
+    this.remainingChunkInfos = [];
+    while (chunkInfoHeap.size() > 0) {
+      this.remainingChunkInfos.push(chunkInfoHeap.pop());
+    }
+  }
+
+  protected override async loadNext(): Promise<void> {
+    const stamp = this.position;
+
+    const firstChunkInfo = this.remainingChunkInfos[0];
+    if (!firstChunkInfo) {
       return;
     }
 
-    // Lookup chunks which contain our stamp inclusive of startTime and endTime
-    let chunkInfos = candidateChunkInfos.filter((info) => {
-      return compare(info.startTime, stamp) <= 0 && compare(stamp, info.endTime) <= 0;
-    });
+    this.remainingChunkInfos[0] = undefined;
 
-    // No chunks contain our stamp, find the next chunk(s) after our stamp
-    if (chunkInfos.length === 0) {
-      let newStamp = stamp;
-      for (const candidateChunk of candidateChunkInfos) {
-        // The first chunk we see sets the new stamp
-        if (newStamp === stamp) {
-          chunkInfos = [candidateChunk];
-          newStamp = candidateChunk.startTime;
-          continue;
-        }
+    let end = firstChunkInfo.endTime;
+    const chunksToLoad: ChunkInfo[] = [firstChunkInfo];
 
-        const compareResult = compare(newStamp, candidateChunk.startTime);
-
-        // If the chunk starts after our new stamp it is ignored since the existing
-        // chunks are closer to the stamp.
-        if (compareResult < 0) {
-          continue;
-        }
-        // If the chunk start is equal to the new stamp, add to chunk infos
-        else if (compareResult === 0) {
-          chunkInfos.push(candidateChunk);
-        }
-        // If the chunk start is before the new stamp it is closer to the stamp.
-        // Make that chunk the new stamp and selected chunk.
-        else if (compareResult > 0) {
-          chunkInfos = [candidateChunk];
-          newStamp = candidateChunk.startTime;
-        }
+    for (let idx = 1; idx < this.remainingChunkInfos.length; ++idx) {
+      const nextChunkInfo = this.remainingChunkInfos[idx];
+      if (!nextChunkInfo) {
+        continue;
       }
 
-      // update the stamp to our chunk start
-      stamp = newStamp;
+      // The chunk starts after our selected end time, we end chunk selection
+      if (compare(nextChunkInfo.startTime, end) > 0) {
+        break;
+      }
+
+      // The chunk starts after our start, but before end so we will load it.
+      chunksToLoad.push(nextChunkInfo);
+
+      // If the chunk ends before or at the end time, we have fully consumed it.
+      // Remove it from the remainingChunkInfos.
+      const endCompare = compare(nextChunkInfo.endTime, end);
+      if (endCompare <= 0) {
+        this.remainingChunkInfos[idx] = undefined;
+      }
     }
+
+    // filter out undefined chunk infos
+    this.remainingChunkInfos = this.remainingChunkInfos.filter(Boolean);
 
     // End of file or no more candidates
-    if (chunkInfos.length === 0) {
+    if (chunksToLoad.length === 0) {
       return;
-    }
-
-    // The end time is the maximum end time of all the chunks we've selected
-    let end = chunkInfos[0]!.endTime;
-    for (const info of chunkInfos) {
-      if (compare(info.endTime, end) > 0) {
-        end = info.endTime;
-      }
-    }
-
-    // There might be some candidate chunks which start after our stamp and before the end time.
-    // Since we plan to read to _end_, we need to include these chunks as well.
-    for (const info of candidateChunkInfos) {
-      // NOTE: startTime is strictly greater than stamp because start times equal to stamp
-      // would have already been considered and we should not include chunks twice.
-      if (compare(info.startTime, stamp) > 0 && compare(info.startTime, end) <= 0) {
-        chunkInfos.push(info);
-      }
     }
 
     // Add 1 nsec to make end 1 past the end for the next read
@@ -92,7 +84,7 @@ export class ForwardIterator extends BaseIterator {
 
     const heap = this.heap;
     const newCache = new Map<number, ChunkReadResult>();
-    for (const chunkInfo of chunkInfos) {
+    for (const chunkInfo of chunksToLoad) {
       let result = this.cachedChunkReadResults.get(chunkInfo.chunkPosition);
       if (!result) {
         result = await this.reader.readChunk(chunkInfo, this.decompress);

--- a/src/ForwardIterator.ts
+++ b/src/ForwardIterator.ts
@@ -21,17 +21,6 @@ export class ForwardIterator extends BaseIterator {
       return compare(info.endTime, stamp) >= 0;
     });
 
-    // If we only want specific connections (i.e. topics), then we further filter
-    // to only the chunks with those topics
-    const connectionIds = this.connectionIds;
-    if (connectionIds) {
-      candidateChunkInfos = candidateChunkInfos.filter((info) => {
-        return info.connections.find((conn) => {
-          return connectionIds.has(conn.conn);
-        });
-      });
-    }
-
     if (candidateChunkInfos.length === 0) {
       return;
     }

--- a/src/ReverseIterator.test.ts
+++ b/src/ReverseIterator.test.ts
@@ -250,7 +250,7 @@ describe("ReverseIterator", () => {
 
     const actualMessages = await consumeMessages(iterator);
     expect(actualMessages).toEqual(
-      expectedMessages.reverse().filter((msg) => msg.timestamp.nsec <= 5 && msg.connectionId == 1),
+      expectedMessages.reverse().filter((msg) => msg.timestamp.nsec <= 5 && msg.connectionId === 1),
     );
   });
 });

--- a/src/ReverseIterator.test.ts
+++ b/src/ReverseIterator.test.ts
@@ -179,4 +179,78 @@ describe("ReverseIterator", () => {
     const actualMessages = await consumeMessages(iterator);
     expect(actualMessages).toEqual(expectedMessages.reverse());
   });
+
+  // Test when the there is a chunk with messages before and after the position BUT
+  // the messages we want are after our position in the chunk so we need the previous chunk.
+  //
+  // [AABB][AABB]
+  //        ^
+  it("should iterate when messages are before position and after", async () => {
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 1,
+              value: 2,
+            },
+            {
+              connection: 1,
+              time: 2,
+              value: 3,
+            },
+            {
+              connection: 1,
+              time: 3,
+              value: 4,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 4,
+              value: 5,
+            },
+            {
+              connection: 0,
+              time: 5,
+              value: 6,
+            },
+            {
+              connection: 1,
+              time: 6,
+              value: 7,
+            },
+            {
+              connection: 1,
+              time: 7,
+              value: 8,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ReverseIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 5 },
+      topics: ["/1"],
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(
+      expectedMessages.reverse().filter((msg) => msg.timestamp.nsec <= 5 && msg.connectionId == 1),
+    );
+  });
 });

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -21,17 +21,6 @@ export class ReverseIterator extends BaseIterator {
       return compare(info.startTime, stamp) <= 0;
     });
 
-    // If we only want specific connections (i.e. topics), then we further filter
-    // to only the chunks with those topics
-    const connectionIds = this.connectionIds;
-    if (connectionIds) {
-      candidateChunkInfos = candidateChunkInfos.filter((info) => {
-        return info.connections.find((conn) => {
-          return connectionIds.has(conn.conn);
-        });
-      });
-    }
-
     if (candidateChunkInfos.length === 0) {
       return;
     }

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -1,90 +1,81 @@
 import { compare, subtract as subTime } from "@foxglove/rostime";
+import Heap from "heap";
 
 import { BaseIterator } from "./BaseIterator";
+import { ChunkInfo } from "./record";
 import { IteratorConstructorArgs, ChunkReadResult } from "./types";
 
 export class ReverseIterator extends BaseIterator {
+  private remainingChunkInfos: (ChunkInfo | undefined)[];
+
   constructor(args: IteratorConstructorArgs) {
     // Sort by largest timestamp first
     super(args, (a, b) => {
       return compare(b.time, a.time);
     });
-  }
-
-  protected override async loadNext(): Promise<void> {
-    let stamp = this.position;
 
     // These are all chunks that we can consider for iteration.
     // Only consider chunks with a start before or equal to our position.
     // Chunks starting after our position are not part of reverse iteration
-    let candidateChunkInfos = this.chunkInfos.filter((info) => {
-      return compare(info.startTime, stamp) <= 0;
+    this.chunkInfos = this.chunkInfos.filter((info) => {
+      return compare(info.startTime, this.position) <= 0;
     });
 
-    if (candidateChunkInfos.length === 0) {
+    // The chunk info heap sorts chunk infos by decreasing end time
+    const chunkInfoHeap = new Heap<ChunkInfo>((a, b) => {
+      return compare(b.endTime, a.endTime);
+    });
+
+    for (const info of this.chunkInfos) {
+      chunkInfoHeap.insert(info);
+    }
+
+    this.remainingChunkInfos = [];
+    while (chunkInfoHeap.size() > 0) {
+      this.remainingChunkInfos.push(chunkInfoHeap.pop());
+    }
+  }
+
+  protected override async loadNext(): Promise<void> {
+    const stamp = this.position;
+
+    const firstChunkInfo = this.remainingChunkInfos[0];
+    if (!firstChunkInfo) {
       return;
     }
 
-    // Lookup chunks which contain our stamp inclusive of startTime and endTime
-    let chunkInfos = candidateChunkInfos.filter((info) => {
-      return compare(info.startTime, stamp) <= 0 && compare(stamp, info.endTime) <= 0;
-    });
+    this.remainingChunkInfos[0] = undefined;
 
-    // No chunks contain our stamp, find the next chunk(s) before our stamp
-    if (chunkInfos.length === 0) {
-      let newStamp = stamp;
-      for (const candidateChunk of candidateChunkInfos) {
-        // The first chunk we see sets the new stamp
-        if (newStamp === stamp) {
-          chunkInfos = [candidateChunk];
-          newStamp = candidateChunk.endTime;
-          continue;
-        }
+    let start = firstChunkInfo.startTime;
+    const chunksToLoad: ChunkInfo[] = [firstChunkInfo];
 
-        const compareResult = compare(candidateChunk.endTime, newStamp);
-
-        // If the chunk ends before our new stamp it is ignored since the existing
-        // chunks are closer to the stamp.
-        if (compareResult < 0) {
-          continue;
-        }
-        // If the chunk end is equal to the new stamp, add to chunk infos
-        else if (compareResult === 0) {
-          chunkInfos.push(candidateChunk);
-        }
-        // If the chunk end is after the new stamp it is closer to the stamp.
-        // Make that chunk the new stamp and selected chunk.
-        else if (compareResult > 0) {
-          chunkInfos = [candidateChunk];
-          newStamp = candidateChunk.endTime;
-        }
+    for (let idx = 1; idx < this.remainingChunkInfos.length; ++idx) {
+      const nextChunkInfo = this.remainingChunkInfos[idx];
+      if (!nextChunkInfo) {
+        continue;
       }
 
-      // update the stamp to our chunk start
-      stamp = newStamp;
+      // The chunk ends before our selected start, we end chunk selection
+      if (compare(nextChunkInfo.endTime, start) < 0) {
+        break;
+      }
+
+      // The chunk ends after our start so we will load it
+      chunksToLoad.push(nextChunkInfo);
+
+      // If the chunk starts after or at the start time, we have fully consumed it
+      const startCompare = compare(nextChunkInfo.startTime, start);
+      if (startCompare >= 0) {
+        this.remainingChunkInfos[idx] = undefined;
+      }
     }
+
+    // filter out undefined chunk infos
+    this.remainingChunkInfos = this.remainingChunkInfos.filter(Boolean);
 
     // End of file or no more candidates
-    if (chunkInfos.length === 0) {
+    if (chunksToLoad.length === 0) {
       return;
-    }
-
-    // Get the earliest start time across all the chunks we've selected
-    let start = chunkInfos[0]!.startTime;
-    for (const info of chunkInfos) {
-      if (compare(info.startTime, start) < 0) {
-        start = info.startTime;
-      }
-    }
-
-    // There might be some candidate chunks which end between our start and stamp.
-    // Since we read from start to stamp, we need to include those chunks as well.
-    for (const info of candidateChunkInfos) {
-      // NOTE: end time is strictly less than stamp because end times equal to stamp
-      // have already been considered and we should not include chunks twice.
-      if (compare(info.endTime, start) >= 0 && compare(info.endTime, stamp) < 0) {
-        chunkInfos.push(info);
-      }
     }
 
     // Subtract 1 nsec to make the next position 1 before
@@ -92,7 +83,7 @@ export class ReverseIterator extends BaseIterator {
 
     const heap = this.heap;
     const newCache = new Map<number, ChunkReadResult>();
-    for (const chunkInfo of chunkInfos) {
+    for (const chunkInfo of chunksToLoad) {
       let result = this.cachedChunkReadResults.get(chunkInfo.chunkPosition);
       if (!result) {
         result = await this.reader.readChunk(chunkInfo, this.decompress);


### PR DESCRIPTION
When starting in the middle of a chunk, its possible the messages for our topic are _behind_ the position. In that case, we end up with an empty heap. This fixes the behavior to try again when the first set of candidate chunks results in no messages.
    
Add a test to ensure the behavior does not regress.