### PR TITLE
Fix parsing

### DIFF
--- a/src/BaseIterator.ts
+++ b/src/BaseIterator.ts
@@ -33,6 +33,7 @@ export abstract class BaseIterator implements MessageIterator {
     this.reader = args.reader;
     this.chunkInfos = args.chunkInfos;
     this.heap = new Heap(compare);
+    this.parse = args.parse;
 
     // if we want to filter by topic, make a list of connection ids to allow
     if (args.topics) {


### PR DESCRIPTION
Message parsing was not happening even when parse was true (or by default) because the BaseIterator constructor did not initialize its parse member with the incoming parse argument.