### PR TITLE
Use slice to read a record from a buffer

### DIFF
--- a/src/BagReader.ts
+++ b/src/BagReader.ts
@@ -242,7 +242,7 @@ export default class BagReader {
     const dataOffset = 4 + headerLength + 4;
     const dataLength = view.getInt32(4 + headerLength, LITTLE_ENDIAN);
 
-    const data = buffer.subarray(dataOffset, dataOffset + dataLength);
+    const data = buffer.slice(dataOffset, dataOffset + dataLength);
 
     record.parseData(data);
 


### PR DESCRIPTION
I have the following bag reading script. This script reads a specific topic from a bag file and stores the raw message data (no parsing) in an array of all messages. This behavior mirrors that of a bag player that might want to buffer some messages in cache for playback.

```typescript
const allmsg = [];

const interval = setInterval(() => {
  console.log(memoryUsage().arrayBuffers);
}, 1000);

for await (const result of bag.messageIterator({ topics: ["/some/small/topic"] })) {
  allmsg.push(result);
}
```

When I run this script on a large (17GB) bag file. The recorded memory usage is as shown:

<img width="597" alt="Screen Shot 2022-09-29 at 8 35 24 AM" src="https://user-images.githubusercontent.com/84792/193137158-f76f02d4-5713-41f7-a01e-a2ffe24efed0.png">

Even tho I am interesting in caching only a single smaller topic the memory continues to grow to match the side of the file. This is because the data for each message is a `subarray` of the original chunk and continues to keep a reference to the chunk around.

Below is the same script when run after the change in this PR:

<img width="591" alt="Screen Shot 2022-09-29 at 8 41 48 AM" src="https://user-images.githubusercontent.com/84792/193137446-0a6de04f-1899-4061-b209-86a716dd4acc.png">

---
When I have a message I am inclined to think of this message as a standalone and not worry that it might keep references to lots of other data. The tradeoff is that each record read has to copy the data from the chunk into a smaller buffer for that record.