### PR TITLE
fix: forwarditerator loss data

### DIFF
--- a/src/BaseIterator.ts
+++ b/src/BaseIterator.ts
@@ -55,7 +55,10 @@ export abstract class BaseIterator implements MessageIterator {
     }
   }
 
-  // Load the next set of messages into the heap
+  /**
+   * Load the next set of messages into the heap
+   * @returns False if no more messages can be loaded, True otherwise.
+   */
   protected abstract loadNext(): Promise<boolean>;
 
   /**
@@ -63,25 +66,13 @@ export abstract class BaseIterator implements MessageIterator {
    */
   async *[Symbol.asyncIterator](): AsyncIterator<MessageEvent> {
     while (true) {
+      // Keep on reading chunks into the heap until no more chunk can be loaded (EOF)
       while (!this.heap.front()) {
-        const done = await this.loadNext();
-        if (done) {
+        const chunkLoaded = await this.loadNext();
+        if (!chunkLoaded) {
           return;
         }
       }
-
-      // if (!this.heap.front()) {
-      //   await this.loadNext();
-      // }
-
-      // // The first load may place us in the middle of a chunk. The topic messages we care
-      // // about may already be "behind" us.
-      // //
-      // // When that happens, we end up with an empty heap and need to try loading one more time.
-      // // This next load will access the next chunks with messages for our topic (or EOF).
-      // if (!this.heap.front()) {
-      //   await this.loadNext();
-      // }
 
       const item = this.heap.pop();
       if (!item) {

--- a/src/ForwardIterator.test.ts
+++ b/src/ForwardIterator.test.ts
@@ -186,4 +186,101 @@ describe("ForwardIterator", () => {
     const actualMessages = await consumeMessages(iterator);
     expect(actualMessages).toEqual(expectedMessages.filter((msg) => msg.timestamp.nsec >= 4));
   });
+
+  it("should iterate when messages are before position and after v1", async () => {
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 1,
+              time: 2,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 5,
+              value: 1,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 1,
+              value: 3,
+            },
+            {
+              connection: 2,
+              time: 3,
+              value: 3,
+            },
+            {
+              connection: 0,
+              time: 6,
+              value: 3,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 2,
+              value: 5,
+            },
+            {
+              connection: 1,
+              time: 4,
+              value: 5,
+            },
+            {
+              connection: 0,
+              time: 7,
+              value: 5,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 8,
+              value: 5,
+            },
+            {
+              connection: 1,
+              time: 9,
+              value: 5,
+            },
+            {
+              connection: 0,
+              time: 10,
+              value: 5,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ForwardIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 0 },
+      topics: ["/1", "/2"],
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(
+      expectedMessages.filter((msg) => ["/1", "/2"].includes(msg.topic)),
+    );
+  });
 });

--- a/src/ForwardIterator.test.ts
+++ b/src/ForwardIterator.test.ts
@@ -187,7 +187,14 @@ describe("ForwardIterator", () => {
     expect(actualMessages).toEqual(expectedMessages.filter((msg) => msg.timestamp.nsec >= 4));
   });
 
-  it("should iterate when messages are before position and after v1", async () => {
+  it("should iterate over messages in overlapping and non-overlapping chunks", async () => {
+    /* Chunk ordering (shown numbers are connection number, X-axis is time):
+     *
+     * 0 --------- 1 --------------- 0
+     *       0 --------- 2 --------------- 0
+     *             0 --------- 1 --------------- 0
+     *                                                 0 --- 1 --- 0
+     */
     const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
       chunks: [
         {

--- a/src/ForwardIterator.ts
+++ b/src/ForwardIterator.ts
@@ -41,7 +41,7 @@ export class ForwardIterator extends BaseIterator {
 
     const firstChunkInfo = this.remainingChunkInfos[0];
     if (!firstChunkInfo) {
-      return true;
+      return false;
     }
 
     this.remainingChunkInfos[0] = undefined;
@@ -76,7 +76,7 @@ export class ForwardIterator extends BaseIterator {
 
     // End of file or no more candidates
     if (chunksToLoad.length === 0) {
-      return true;
+      return false;
     }
 
     // Add 1 nsec to make end 1 past the end for the next read
@@ -111,6 +111,6 @@ export class ForwardIterator extends BaseIterator {
     }
 
     this.cachedChunkReadResults = newCache;
-    return false;
+    return true;
   }
 }

--- a/src/ForwardIterator.ts
+++ b/src/ForwardIterator.ts
@@ -36,12 +36,12 @@ export class ForwardIterator extends BaseIterator {
     }
   }
 
-  protected override async loadNext(): Promise<void> {
+  protected override async loadNext(): Promise<boolean> {
     const stamp = this.position;
 
     const firstChunkInfo = this.remainingChunkInfos[0];
     if (!firstChunkInfo) {
-      return;
+      return true;
     }
 
     this.remainingChunkInfos[0] = undefined;
@@ -76,7 +76,7 @@ export class ForwardIterator extends BaseIterator {
 
     // End of file or no more candidates
     if (chunksToLoad.length === 0) {
-      return;
+      return true;
     }
 
     // Add 1 nsec to make end 1 past the end for the next read
@@ -111,5 +111,6 @@ export class ForwardIterator extends BaseIterator {
     }
 
     this.cachedChunkReadResults = newCache;
+    return false;
   }
 }

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -41,7 +41,7 @@ export class ReverseIterator extends BaseIterator {
 
     const firstChunkInfo = this.remainingChunkInfos[0];
     if (!firstChunkInfo) {
-      return true;
+      return false;
     }
 
     this.remainingChunkInfos[0] = undefined;
@@ -75,7 +75,7 @@ export class ReverseIterator extends BaseIterator {
 
     // End of file or no more candidates
     if (chunksToLoad.length === 0) {
-      return true;
+      return false;
     }
 
     // Subtract 1 nsec to make the next position 1 before
@@ -110,6 +110,6 @@ export class ReverseIterator extends BaseIterator {
     }
 
     this.cachedChunkReadResults = newCache;
-    return false;
+    return true;
   }
 }

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -3,7 +3,7 @@ import Heap from "heap";
 
 import { BaseIterator } from "./BaseIterator";
 import { ChunkInfo } from "./record";
-import { IteratorConstructorArgs, ChunkReadResult } from "./types";
+import { ChunkReadResult, IteratorConstructorArgs } from "./types";
 
 export class ReverseIterator extends BaseIterator {
   private remainingChunkInfos: (ChunkInfo | undefined)[];
@@ -36,12 +36,12 @@ export class ReverseIterator extends BaseIterator {
     }
   }
 
-  protected override async loadNext(): Promise<void> {
+  protected override async loadNext(): Promise<boolean> {
     const stamp = this.position;
 
     const firstChunkInfo = this.remainingChunkInfos[0];
     if (!firstChunkInfo) {
-      return;
+      return true;
     }
 
     this.remainingChunkInfos[0] = undefined;
@@ -75,7 +75,7 @@ export class ReverseIterator extends BaseIterator {
 
     // End of file or no more candidates
     if (chunksToLoad.length === 0) {
-      return;
+      return true;
     }
 
     // Subtract 1 nsec to make the next position 1 before
@@ -110,5 +110,6 @@ export class ReverseIterator extends BaseIterator {
     }
 
     this.cachedChunkReadResults = newCache;
+    return false;
   }
 }


### PR DESCRIPTION
### Public-Facing Changes
None
<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description

I really like this bag library. Its code is clear and it has made me familiar with the way bags are read. This is my first time submitting a PR. If there are any issues, please point them out. Thank you.



I lost data in my bag (I'm not sure if this is an issue with the bag itself), and after debugging, I identified the problem. The cause of the problem is the use of BaseIterator for loadNext. It determines that when the timestamp is in the middle position, we may lose data and therefore load Next again.



But when the chunks overlap, this judgment may encounter some issues.
![image](https://github.com/foxglove/rosbag/assets/73457728/d94df984-aebd-44fb-9bae-308870a7dd7c)
In my scenario, starting from {sec: 0, nsec: 0}, when reading topic=['A ',' B '], we first read A1, B1, A2, and then position is at position Other (red line). After the heap is consumed, we call LoadNext (to read chunkB, chunkC) and cannot read the data. We then perform an additional loadNext, but still cannot read the data at chunkC, and then exit. We lost the data for A3.

The above is the real-life scenario I encountered. If we remove ChunkA and directly read from the position at time=5, the same error will occur, or in other words, the[ previous fix](https://github.com/foxglove/rosbag/pull/57) did not completely solve the problem.




My fix is to directly change the judgment of loadNext to a while loop until EOF. I have passed all tests and the ones I added. Is there any problem with doing so?


