### PR TITLE
Fix iterator not iterating over all chunks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 // -*- jsonc -*-
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,

--- a/src/ForwardIterator.test.ts
+++ b/src/ForwardIterator.test.ts
@@ -186,4 +186,108 @@ describe("ForwardIterator", () => {
     const actualMessages = await consumeMessages(iterator);
     expect(actualMessages).toEqual(expectedMessages.filter((msg) => msg.timestamp.nsec >= 4));
   });
+
+  it("should iterate over messages in overlapping and non-overlapping chunks", async () => {
+    /* Chunk ordering (shown numbers are connection number, X-axis is time):
+     *
+     * 0 --------- 1 --------------- 0
+     *       0 --------- 2 --------------- 0
+     *             0 --------- 1 --------------- 0
+     *                                                 0 --- 1 --- 0
+     */
+    const { connections, chunkInfos, reader, expectedMessages } = generateFixtures({
+      chunks: [
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 0,
+              value: 1,
+            },
+            {
+              connection: 1,
+              time: 2,
+              value: 1,
+            },
+            {
+              connection: 0,
+              time: 5,
+              value: 1,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 1,
+              value: 3,
+            },
+            {
+              connection: 2,
+              time: 3,
+              value: 3,
+            },
+            {
+              connection: 0,
+              time: 6,
+              value: 3,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 2,
+              value: 5,
+            },
+            {
+              connection: 1,
+              time: 4,
+              value: 5,
+            },
+            {
+              connection: 0,
+              time: 7,
+              value: 5,
+            },
+          ],
+        },
+        {
+          messages: [
+            {
+              connection: 0,
+              time: 8,
+              value: 5,
+            },
+            {
+              connection: 1,
+              time: 9,
+              value: 5,
+            },
+            {
+              connection: 0,
+              time: 10,
+              value: 5,
+            },
+          ],
+        },
+      ],
+    });
+
+    const iterator = new ForwardIterator({
+      connections,
+      chunkInfos,
+      decompress: {},
+      reader,
+      position: { sec: 0, nsec: 0 },
+      topics: ["/1", "/2"],
+    });
+
+    const actualMessages = await consumeMessages(iterator);
+    expect(actualMessages).toEqual(
+      expectedMessages.filter((msg) => ["/1", "/2"].includes(msg.topic)),
+    );
+  });
 });

--- a/src/ForwardIterator.ts
+++ b/src/ForwardIterator.ts
@@ -36,12 +36,12 @@ export class ForwardIterator extends BaseIterator {
     }
   }
 
-  protected override async loadNext(): Promise<void> {
+  protected override async loadNext(): Promise<boolean> {
     const stamp = this.position;
 
     const firstChunkInfo = this.remainingChunkInfos[0];
     if (!firstChunkInfo) {
-      return;
+      return false;
     }
 
     this.remainingChunkInfos[0] = undefined;
@@ -76,7 +76,7 @@ export class ForwardIterator extends BaseIterator {
 
     // End of file or no more candidates
     if (chunksToLoad.length === 0) {
-      return;
+      return false;
     }
 
     // Add 1 nsec to make end 1 past the end for the next read
@@ -111,5 +111,6 @@ export class ForwardIterator extends BaseIterator {
     }
 
     this.cachedChunkReadResults = newCache;
+    return true;
   }
 }

--- a/src/ReverseIterator.ts
+++ b/src/ReverseIterator.ts
@@ -3,7 +3,7 @@ import Heap from "heap";
 
 import { BaseIterator } from "./BaseIterator";
 import { ChunkInfo } from "./record";
-import { IteratorConstructorArgs, ChunkReadResult } from "./types";
+import { ChunkReadResult, IteratorConstructorArgs } from "./types";
 
 export class ReverseIterator extends BaseIterator {
   private remainingChunkInfos: (ChunkInfo | undefined)[];
@@ -36,12 +36,12 @@ export class ReverseIterator extends BaseIterator {
     }
   }
 
-  protected override async loadNext(): Promise<void> {
+  protected override async loadNext(): Promise<boolean> {
     const stamp = this.position;
 
     const firstChunkInfo = this.remainingChunkInfos[0];
     if (!firstChunkInfo) {
-      return;
+      return false;
     }
 
     this.remainingChunkInfos[0] = undefined;
@@ -75,7 +75,7 @@ export class ReverseIterator extends BaseIterator {
 
     // End of file or no more candidates
     if (chunksToLoad.length === 0) {
-      return;
+      return false;
     }
 
     // Subtract 1 nsec to make the next position 1 before
@@ -110,5 +110,6 @@ export class ReverseIterator extends BaseIterator {
     }
 
     this.cachedChunkReadResults = newCache;
+    return true;
   }
 }


### PR DESCRIPTION
### Public-Facing Changes
Fix iterator not iterating over all chunks

### Description
Supersedes #72

> 
> ![image](https://github.com/foxglove/rosbag/assets/73457728/d94df984-aebd-44fb-9bae-308870a7dd7c)
> In my scenario, starting from {sec: 0, nsec: 0}, when reading topic=['A ',' B '], we first read A1, B1, A2, and then position is at position Other (red line). After the heap is consumed, we call LoadNext (to read chunkB, chunkC) and cannot read the data. We then perform an additional loadNext, but still cannot read the data at chunkC, and then exit. We lost the data for A3.
> 
